### PR TITLE
Added Pan Boundary Padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ We've rewritten most of the logic in the original library to address the followi
 ### Installation
 
 In your package.json:
-`"@openspacelabs/react-native-zoomable-view": "git+ssh://git@github.com:openspacelabs/react-native-zoomable-view.git#d2edca464073b7b86991a8b93572b75c585c16ab",`
+
+```json
+"@openspacelabs/react-native-zoomable-view": "git+ssh://git@github.com:openspacelabs/react-native-zoomable-view.git#[some commit hash]",
+```
 
 Run `yarn install` or `npm install`
 
@@ -125,24 +128,25 @@ const styles = StyleSheet.create({
 
 These options can be used to limit and change the zoom behavior.
 
-| name                      | type    | description                                                                                                              | default   |
-| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ | --------- |
-| zoomEnabled               | boolean | Can be used to enable or disable the zooming dynamically                                                                 | true      |
-| initialZoom               | number  | Initial zoom level on startup                                                                                            | 1.0       |
-| maxZoom                   | number  | Maximum possible zoom level (zoom in). Can be set to `null` to allow unlimited zooming                                   | 1.5       |
-| minZoom                   | number  | Minimum possible zoom level (zoom out)                                                                                   | 0.5       |
-| doubleTapDelay            | number  | How much delay will still be recognized as double press (ms)                                                             | 300       |
-| doubleTapZoomToCenter     | boolean | If true, double tapping will always zoom to center of View instead of the direction it was double tapped in              |
-| bindToBorders             | boolean | If true, it makes sure the object stays within box borders                                                               | true      |
-| zoomStep                  | number  | How much zoom should be applied on double tap                                                                            | 0.5       |
-| pinchToZoomInSensitivity  | number  | the level of resistance (sensitivity) to zoom in (0 - 10) - higher is less sensitive                                     | 3         |
-| pinchToZoomOutSensitivity | number  | the level of resistance (sensitivity) to zoom out (0 - 10) - higher is less sensitive                                    | 1         |
-| movementSensibility       | number  | how resistant should shifting the view around be? (0.5 - 5) - higher is less sensitive                                   | 1.9       |
-| initialOffsetX            | number  | The horizontal offset the image should start at                                                                          | 0         |
-| initialOffsetY            | number  | The vertical offset the image should start at                                                                            | 0         |
-| contentHeight             | number  | Specify if you want to treat the height of the **centered** content inside the zoom subject as the zoom subject's height | undefined |
-| contentWidth              | number  | Specify if you want to treat the width of the **centered** content inside the zoom subject as the zoom subject's width   | undefined |
-| longPressDuration         | number  | Duration in ms until a press is considered a long press                                                                  | 700       |
+| name                      | type    | description                                                                                                                                                                                                                                                                                                                          | default   |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
+| zoomEnabled               | boolean | Can be used to enable or disable the zooming dynamically                                                                                                                                                                                                                                                                             | true      |
+| initialZoom               | number  | Initial zoom level on startup                                                                                                                                                                                                                                                                                                        | 1.0       |
+| maxZoom                   | number  | Maximum possible zoom level (zoom in). Can be set to `null` to allow unlimited zooming                                                                                                                                                                                                                                               | 1.5       |
+| minZoom                   | number  | Minimum possible zoom level (zoom out)                                                                                                                                                                                                                                                                                               | 0.5       |
+| doubleTapDelay            | number  | How much delay will still be recognized as double press (ms)                                                                                                                                                                                                                                                                         | 300       |
+| doubleTapZoomToCenter     | boolean | If true, double tapping will always zoom to center of View instead of the direction it was double tapped in                                                                                                                                                                                                                          |
+| bindToBorders             | boolean | If true, it makes sure the object stays within box borders                                                                                                                                                                                                                                                                           | true      |
+| zoomStep                  | number  | How much zoom should be applied on double tap                                                                                                                                                                                                                                                                                        | 0.5       |
+| pinchToZoomInSensitivity  | number  | the level of resistance (sensitivity) to zoom in (0 - 10) - higher is less sensitive                                                                                                                                                                                                                                                 | 3         |
+| pinchToZoomOutSensitivity | number  | the level of resistance (sensitivity) to zoom out (0 - 10) - higher is less sensitive                                                                                                                                                                                                                                                | 1         |
+| movementSensibility       | number  | how resistant should shifting the view around be? (0.5 - 5) - higher is less sensitive                                                                                                                                                                                                                                               | 1.9       |
+| initialOffsetX            | number  | The horizontal offset the image should start at                                                                                                                                                                                                                                                                                      | 0         |
+| initialOffsetY            | number  | The vertical offset the image should start at                                                                                                                                                                                                                                                                                        | 0         |
+| contentHeight             | number  | Specify if you want to treat the height of the **centered** content inside the zoom subject as the zoom subject's height                                                                                                                                                                                                             | undefined |
+| contentWidth              | number  | Specify if you want to treat the width of the **centered** content inside the zoom subject as the zoom subject's width                                                                                                                                                                                                               | undefined |
+| panBoundaryPadding        | number  | At certain scales, the edge of the content is bounded too close to the edge of the container, making it difficult to pan to and interact with the edge of the content. To fix this, we'd wanna allow the content to pan just a little further away from the container's edge. Hence, the "pan boundary padding", measured in pixels. | 0         |
+| longPressDuration         | number  | Duration in ms until a press is considered a long press                                                                                                                                                                                                                                                                              | 700       |
 
 #### Callbacks
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ We've rewritten most of the logic in the original library to address the followi
 - [x] Better internal code organization and documentation
 - [x] Allowed passing in a custom pan and zoom animation values via optional props
 
-
 ## Preview
 
 ![](https://thumbs.gfycat.com/PalatableMeanGnat-size_restricted.gif)
@@ -34,7 +33,7 @@ We've rewritten most of the logic in the original library to address the followi
 ### Installation
 
 In your package.json:
-```"@openspacelabs/react-native-zoomable-view": "git+ssh://git@github.com:openspacelabs/react-native-zoomable-view.git#d2edca464073b7b86991a8b93572b75c585c16ab",```
+`"@openspacelabs/react-native-zoomable-view": "git+ssh://git@github.com:openspacelabs/react-native-zoomable-view.git#d2edca464073b7b86991a8b93572b75c585c16ab",`
 
 Run `yarn install` or `npm install`
 
@@ -126,24 +125,24 @@ const styles = StyleSheet.create({
 
 These options can be used to limit and change the zoom behavior.
 
-| name                      | type    | description                                                                                                                  | default   |
-| ------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- | --------- |
-| zoomEnabled               | boolean | Can be used to enable or disable the zooming dynamically                                                                     | true      |
-| initialZoom               | number  | Initial zoom level on startup                                                                                                | 1.0       |
-| maxZoom                   | number  | Maximum possible zoom level (zoom in). Can be set to `null` to allow unlimited zooming                                       | 1.5       |
-| minZoom                   | number  | Minimum possible zoom level (zoom out)                                                                                       | 0.5       |
-| doubleTapDelay            | number  | How much delay will still be recognized as double press (ms)                                                                 | 300       |
-| doubleTapZoomToCenter     | boolean | If true, double tapping will always zoom to center of View instead of the direction it was double tapped in                  |
-| bindToBorders             | boolean | If true, it makes sure the object stays within box borders                                                                   | true      |
-| zoomStep                  | number  | How much zoom should be applied on double tap                                                                                | 0.5       |
-| pinchToZoomInSensitivity  | number  | the level of resistance (sensitivity) to zoom in (0 - 10) - higher is less sensitive                                         | 3         |
-| pinchToZoomOutSensitivity | number  | the level of resistance (sensitivity) to zoom out (0 - 10) - higher is less sensitive                                        | 1         |
-| movementSensibility       | number  | how resistant should shifting the view around be? (0.5 - 5) - higher is less sensitive                                       | 1.9       |
-| initialOffsetX            | number  | The horizontal offset the image should start at                                                                              | 0         |
-| initialOffsetY            | number  | The vertical offset the image should start at                                                                                | 0         |
-| contentHeight             | number  | Specify if you want to treat the height of the **centered** content inside the zoom subject as the zoom subject's height        | undefined |
-| contentWidth              | number  | Specify if you want to treat the width of the **centered** content inside the zoom subject as the zoom subject's width          | undefined |
-| longPressDuration         | number  | Duration in ms until a press is considered a long press                                                                      | 700       |
+| name                      | type    | description                                                                                                              | default   |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ | --------- |
+| zoomEnabled               | boolean | Can be used to enable or disable the zooming dynamically                                                                 | true      |
+| initialZoom               | number  | Initial zoom level on startup                                                                                            | 1.0       |
+| maxZoom                   | number  | Maximum possible zoom level (zoom in). Can be set to `null` to allow unlimited zooming                                   | 1.5       |
+| minZoom                   | number  | Minimum possible zoom level (zoom out)                                                                                   | 0.5       |
+| doubleTapDelay            | number  | How much delay will still be recognized as double press (ms)                                                             | 300       |
+| doubleTapZoomToCenter     | boolean | If true, double tapping will always zoom to center of View instead of the direction it was double tapped in              |
+| bindToBorders             | boolean | If true, it makes sure the object stays within box borders                                                               | true      |
+| zoomStep                  | number  | How much zoom should be applied on double tap                                                                            | 0.5       |
+| pinchToZoomInSensitivity  | number  | the level of resistance (sensitivity) to zoom in (0 - 10) - higher is less sensitive                                     | 3         |
+| pinchToZoomOutSensitivity | number  | the level of resistance (sensitivity) to zoom out (0 - 10) - higher is less sensitive                                    | 1         |
+| movementSensibility       | number  | how resistant should shifting the view around be? (0.5 - 5) - higher is less sensitive                                   | 1.9       |
+| initialOffsetX            | number  | The horizontal offset the image should start at                                                                          | 0         |
+| initialOffsetY            | number  | The vertical offset the image should start at                                                                            | 0         |
+| contentHeight             | number  | Specify if you want to treat the height of the **centered** content inside the zoom subject as the zoom subject's height | undefined |
+| contentWidth              | number  | Specify if you want to treat the width of the **centered** content inside the zoom subject as the zoom subject's width   | undefined |
+| longPressDuration         | number  | Duration in ms until a press is considered a long press                                                                  | 700       |
 
 #### Callbacks
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -22,6 +22,7 @@ export default function App() {
           // Therefore, we'll feed the zoomable view the 300x100 size.
           contentWidth={300}
           contentHeight={150}
+          panBoundaryPadding={50}
           zoomAnimatedValue={zoomAnimatedValue}
         >
           <View style={styles.contents}>
@@ -63,7 +64,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     padding: 20,
   },
-  contents: { width: 200, height: 400 },
+  contents: { flex: 1, alignSelf: 'stretch' },
   box: { borderWidth: 5, flexShrink: 1, height: 500, width: 310 },
   img: { width: '100%', height: '100%', resizeMode: 'contain' },
   marker: {

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -61,6 +61,9 @@ class ReactNativeZoomableView extends Component<
     zoomStep: 0.5,
     onLongPress: null,
     longPressDuration: 700,
+    contentWidth: undefined,
+    contentHeight: undefined,
+    panBoundaryPadding: 0,
   };
 
   private panAnim = new Animated.ValueXY({ x: 0, y: 0 });
@@ -185,7 +188,8 @@ class ReactNativeZoomableView extends Component<
               offset,
               containerSize,
               contentSize,
-              this.zoomLevel
+              this.zoomLevel,
+              this.props.panBoundaryPadding
             )
           : offset;
 

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -314,7 +314,9 @@ class ReactNativeZoomableView extends Component<
         // in which case these measurements will not represent the true "original" measurements.
         // We just need to make sure the zoomSubjectWrapper perfectly aligns with the zoomSubject
         // (no border, space, or anything between them)
-        this.zoomSubjectWrapperRef.current?.measureInWindow(
+        const zoomSubjectWrapperRef = this.zoomSubjectWrapperRef;
+        // we don't wanna measure when zoomSubjectWrapperRef is not yet available or has been unmounted
+        zoomSubjectWrapperRef.current?.measureInWindow(
           (x, y, width, height) => {
             this.setState({
               originalWidth: width,

--- a/src/helper/applyPanBoundariesToOffset.ts
+++ b/src/helper/applyPanBoundariesToOffset.ts
@@ -7,6 +7,7 @@
  * @param containerSize
  * @param contentSize
  * @param scale
+ * @param boundaryPadding - see README
  *
  * @returns {number}
  */
@@ -14,7 +15,8 @@ export function applyPanBoundariesToOffset(
   offsetScaled: number,
   containerSize: number,
   contentSize: number,
-  scale: number
+  scale: number,
+  boundaryPadding: number
 ) {
   const contentSizeUnscaled = contentSize * scale;
   const offsetUnscaled = offsetScaled * scale;
@@ -27,18 +29,42 @@ export function applyPanBoundariesToOffset(
   const containerStartBorder = 0;
   const containerEndBorder = containerStartBorder + containerSize;
 
-  // if content is smaller than the container,
-  // don't let content move
-  if (contentSizeUnscaled < containerSize) {
+  // do not let boundary padding be greater than the container size or less than 0
+  if (!boundaryPadding || boundaryPadding < 0) boundaryPadding = 0;
+  if (boundaryPadding > containerSize) boundaryPadding = containerSize;
+
+  // Calculate container's measurements with boundary padding applied.
+  // this should shrink the container's size by the amount of the boundary padding,
+  // so that the content inside can be panned a bit further away from the original container's boundaries.
+  const paddedContainerSize = containerSize - boundaryPadding * 2;
+  const paddedContainerStartBorder = containerStartBorder + boundaryPadding;
+  const paddedContainerEndBorder = containerEndBorder - boundaryPadding;
+
+  // if content is smaller than the padded container,
+  // don't let the content move
+  if (contentSizeUnscaled < paddedContainerSize) {
     return 0;
   }
-  // if content is larger than the container,
-  // don't let container go outside of content
-  if (contentEndBorderUnscaled < containerEndBorder) {
-    return (containerSize / 2 - contentSizeUnscaled / 2) / scale;
+
+  // if content is larger than the padded container,
+  // don't let the padded container go outside of content
+
+  // maximum distance the content's center can move from its original position.
+  // assuming the content original center is the container's center.
+  const contentMaxOffsetScaled =
+    (paddedContainerSize / 2 - contentSizeUnscaled / 2) / scale;
+
+  if (
+    // content reaching the end boundary
+    contentEndBorderUnscaled < paddedContainerEndBorder
+  ) {
+    return contentMaxOffsetScaled;
   }
-  if (contentStartBorderUnscaled > containerStartBorder) {
-    return -(containerSize / 2 - contentSizeUnscaled / 2) / scale;
+  if (
+    // content reaching the start boundary
+    contentStartBorderUnscaled > paddedContainerStartBorder
+  ) {
+    return -contentMaxOffsetScaled;
   }
 
   return offsetScaled;

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -30,6 +30,7 @@ export interface ReactNativeZoomableViewProps extends ViewProps {
   initialOffsetY?: number;
   contentWidth?: number;
   contentHeight?: number;
+  panBoundaryPadding?: number;
   maxZoom?: number;
   minZoom?: number;
   doubleTapDelay?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1953,6 +1953,22 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/react-native@^0.65.4":
+  version "0.65.15"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.65.15.tgz#102ebe9fbafa19e6aef3459b8b4cf863cd9c140b"
+  integrity sha512-Ac4TgJBQToCZuA/BLIdGTP2Ya/+l/3mjQWutGKG+t92g3QucDV6innZsBw7M00F1L3U5fgC5guP6co5QQY1D4A==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "17.0.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.34.tgz#797b66d359b692e3f19991b6b07e4b0c706c0102"
+  integrity sha512-46FEGrMjc2+8XhHXILr+3+/sTe3OfzSPU9YGKILLrUYbQ1CLQC9Daqo1KzENGXAWwrFwiY0l4ZbF20gRvgpWTg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/react@^16.9.19":
   version "16.14.17"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.17.tgz#c57fcfb05efa6423f5b65fcd4a75f63f05b162bf"


### PR DESCRIPTION
What is Pan Bounadry Padding?

At certain scales, the edge of the content is bounded too close to the edge of the container, making it difficult to pan to and interact with the edge of the content. To fix this, we'd wanna allow the content to pan just a little further away from the container's edge. Hence, the "pan boundary padding", measured in pixels.