### PR TITLE
Actions for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Checks
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install modules
+      run: yarn
+    - name: Run tsc
+      run: yarn run typescript
+    - name: Run ESLint
+      run: yarn run lint
+    - name: Run tests
+      run: yarn run test
+


### PR DESCRIPTION
I found recently that a PR did not follow linting. This only came to light during the release phase. Unfortunately this meant that I had to make two releases.

It should be enough to add a GH Action to ensure that lint and tsc checks before merging. This will help ensure that contributors pass these checks before their work is merged!