### PR TITLE
fix issues with lint picking up errors due to bad relative paths when…

### DIFF
--- a/src/animations/index.ts
+++ b/src/animations/index.ts
@@ -1,5 +1,5 @@
 import { Animated, Easing } from 'react-native';
-import { Vec2D } from 'src/typings';
+import { Vec2D } from '../typings';
 
 export function getBoundaryCrossedAnim(
   animValue: Animated.Value,

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -1,5 +1,5 @@
 import { GestureResponderEvent, PanResponderGestureState } from 'react-native';
-import { Vec2D } from 'src/typings';
+import { Vec2D } from '../typings';
 
 export { calcNewScaledOffsetForZoomCentering } from './calcNewScaledOffsetForZoomCentering';
 


### PR DESCRIPTION
… consumed in a project and applying lint across the solution.

Example of error while being consumed

source % yarn lint
yarn run v1.22.19
$ tsc --noemit && eslint --ext .js,.jsx,.ts,.tsx ./
node_modules/@openspacelabs/react-native-zoomable-view/src/animations/index.ts:2:23 - error TS2307: Cannot find module 'src/typings' or its corresponding type declarations.

2 import { Vec2D } from 'src/typings';
                        ~~~~~~~~~~~~~

node_modules/@openspacelabs/react-native-zoomable-view/src/helper/index.ts:2:23 - error TS2307: Cannot find module 'src/typings' or its corresponding type declarations.

2 import { Vec2D } from 'src/typings';
                        ~~~~~~~~~~~~~


Found 2 errors in 2 files.

Errors  Files
     1  node_modules/@openspacelabs/react-native-zoomable-view/src/animations/index.ts:2
     1  node_modules/@openspacelabs/react-native-zoomable-view/src/helper/index.ts:2
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.