### PR TITLE
Fix ReactNativeZoomableViewProps export

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,9 @@
 import ReactNativeZoomableView from './ReactNativeZoomableView';
 import ReactNativeZoomableViewWithGestures from './ReactNativeZoomableViewWithGestures';
-import { ReactNativeZoomableViewProps, ZoomableViewEvent } from './typings';
+import type {
+  ReactNativeZoomableViewProps,
+  ZoomableViewEvent,
+} from './typings';
 
 export {
   ReactNativeZoomableView,


### PR DESCRIPTION
Fixes #22

From the issue:

> We are using this package in Expo with react-native-web. There is no issue in native application, but web displays following warnings right after build and also in a browser console:

I think the problem here has been that these imports were `import` and not `import type`. Updating this code causes those imports to be excluded from the module javascript and this should solve the issue.