### PR TITLE
onShouldBlockNativeResponder defaults to true

### DIFF
--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -132,7 +132,7 @@ class ReactNativeZoomableView extends Component<
           evt,
           gestureState,
           this._getZoomableViewEventObject()
-        ),
+        ) ?? true,
     });
 
     this.zoomSubjectWrapperRef = createRef<View>();


### PR DESCRIPTION
The `onShouldBlockNativeResponder` prop now defaults to true