### PR TITLE
Fix bug where default value of onShouldBlockNativeResponder was false instead of true

### DIFF
--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -127,8 +127,9 @@ class ReactNativeZoomableView extends Component<
           gestureState,
           this._getZoomableViewEventObject()
         ),
+      // Defaults to true to prevent parent components, such as React Navigation's tab view, from taking over as responder.
       onShouldBlockNativeResponder: (evt, gestureState) =>
-        !!this.props.onShouldBlockNativeResponder?.(
+        this.props.onShouldBlockNativeResponder?.(
           evt,
           gestureState,
           this._getZoomableViewEventObject()


### PR DESCRIPTION
The `!!` meant that an absent onShouldBlockNativeResponder prop resolved to false, and the `??` never coalesced to true