### PR TITLE
fix: allow ZoomableView ref to be utilised via ZoomableViewWithGestures

### DIFF
--- a/src/ReactNativeZoomableViewWithGestures.tsx
+++ b/src/ReactNativeZoomableViewWithGestures.tsx
@@ -16,6 +16,13 @@ class ReactNativeZoomableViewWithGestures extends React.Component<
   ReactNativeZoomableViewWithGesturesProps,
   ReactNativeZoomableViewState
 > {
+  zoomableViewRef: React.RefObject<ReactNativeZoomableView> | undefined;
+
+  constructor(props: ReactNativeZoomableViewWithGesturesProps) {
+    super(props);
+    this.zoomableViewRef = React.createRef<ReactNativeZoomableView>();
+  }
+
   _onShiftingEnd = (e, gestureState, zoomableViewState) => {
     if (this.props.onShiftingEnd) {
       this.props.onShiftingEnd(e, gestureState, zoomableViewState);
@@ -207,6 +214,7 @@ class ReactNativeZoomableViewWithGestures extends React.Component<
     return (
       <ReactNativeZoomableView
         {...this.props}
+        ref={this.zoomableViewRef}
         onShiftingEnd={this._onShiftingEnd}
       />
     );


### PR DESCRIPTION
Fixes https://github.com/openspacelabs/react-native-zoomable-view/issues/94.

Updates the `ReactNativeZoomableViewWithGestures` component to manage the ref of the inner `ReactNativeZoomableView` component.

This allows users of `ReactNativeZoomableViewWithGestures` to still imperatively call the `zoomTo`, `zoomBy`, `moveBy`, `moveTo` functions of the underlying `ReactNativeZoomableView`.

Example:

```jsx
const ref = useRef<ReactNativeZoomableViewWithGestures>(null);

return <>
  <ReactNativeZoomableViewWithGestures {ref} ... />
  <Button text="Zoom" onPress={() => {
    ref.current?.zoomableViewRef?.current?.zoomBy(2);
  }} />  
</>
```