### PR TITLE
fix couldCallSwipeEvent from returning false when not all props are provided

### DIFF
--- a/src/ReactNativeZoomableViewWithGestures.tsx
+++ b/src/ReactNativeZoomableViewWithGestures.tsx
@@ -61,7 +61,7 @@ class ReactNativeZoomableViewWithGestures extends React.Component<
       return false;
     }
 
-    return onSwipe && onSwipeUp && onSwipeDown && onSwipeLeft && onSwipeRight;
+    return onSwipe || onSwipeUp || onSwipeDown || onSwipeLeft || onSwipeRight;
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/openspacelabs/react-native-zoomable-view/issues/96

`onSwipe`, `onSwipeUp`, `onSwipeDown`, `onSwipeLeft`, and `onSwipeRight` are all optional props for `ReactNativeZoomableViewWithGestures` but `couldCallSwipeEvent()` returns false when one of these props is not provided. This PR allows `couldCallSwipeEvent` to return true if at least one of these props are provided.