### PR TITLE
Allow static pin to move off the map

### DIFF
--- a/src/helper/coordinateConversion.ts
+++ b/src/helper/coordinateConversion.ts
@@ -119,13 +119,5 @@ export function viewportPositionToImagePosition({
       resizedImgScale,
   };
 
-  if (
-    pointOnSheet.x < 0 ||
-    pointOnSheet.x > imageSize.width ||
-    pointOnSheet.y < 0 ||
-    pointOnSheet.y > imageSize.height
-  )
-    return null;
-
   return pointOnSheet;
 }


### PR DESCRIPTION
In our application, the static pin is used as a cursor for selecting content. 

When the content is near the edge of the zoomed image, we need the coordinates back from the library in order to select it – `null` doesn't give us anything here.

Unfortunately this means – the change here is that it's up to the client code to determine whether the point is valid for its use cases. I think this is a reasonable change – we shouldn't have any opinion about whether a point is valid or not. In some instances, points are only valid when they're on the content image – but not in all instances, especially for the static pin.

This can be a prop if it really needs to be.