### PR TITLE
Persist event for onLongPress callback

### DIFF
--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -481,6 +481,7 @@ class ReactNativeZoomableView extends Component<
     PanResponderCallbacks['onPanResponderGrant']
   > = (e, gestureState) => {
     if (this.props.onLongPress) {
+      e.persist();
       this.longPressTimeout = setTimeout(() => {
         this.props.onLongPress?.(
           e,


### PR DESCRIPTION
Due to timeout, e must be persisted to not be overwritten

Resolves https://github.com/openspacelabs/react-native-zoomable-view/issues/137