### PR TITLE
Sorting imports

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useRef, useState } from 'react';
-import { View, Text, Image, Animated, Button } from 'react-native';
-
 import { ReactNativeZoomableView } from '@openspacelabs/react-native-zoomable-view';
-import { styles } from './style';
 import { debounce } from 'lodash';
+import React, { useCallback, useRef, useState } from 'react';
+import { Animated, Button, Image, Text, View } from 'react-native';
+
 import { applyContainResizeMode } from '../src/helper/coordinateConversion';
+import { styles } from './style';
 
 const kittenSize = 800;
 const uri = `https://placekitten.com/${kittenSize}/${kittenSize}`;

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "husky": "^4.2.5",
     "jest": "^26.0.1",
     "pod-install": "^0.1.0",
@@ -139,7 +140,8 @@
     "plugins": [
       "prettier",
       "react",
-      "react-native"
+      "react-native",
+      "simple-import-sort"
     ],
     "rules": {
       "prettier/prettier": [
@@ -152,7 +154,9 @@
           "useTabs": false
         }
       ],
-      "react-native/no-color-literals": "off"
+      "react-native/no-color-literals": "off",
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error"
     },
     "overrides": [
       {

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -1,3 +1,4 @@
+import { debounce } from 'lodash';
 import React, { Component, createRef, RefObject } from 'react';
 import {
   Animated,
@@ -12,15 +13,12 @@ import {
 } from 'react-native';
 
 import {
-  Vec2D,
-  ReactNativeZoomableViewProps,
-  ReactNativeZoomableViewState,
-  TouchPoint,
-  ZoomableViewEvent,
-  Size2D,
-} from './typings';
-
+  getBoundaryCrossedAnim,
+  getPanMomentumDecayAnim,
+  getZoomToAnimation,
+} from './animations';
 import { AnimatedTouchFeedback } from './components';
+import { StaticPin } from './components/StaticPin';
 import { DebugTouchPoint } from './debugHelper';
 import {
   calcGestureCenterPoint,
@@ -29,13 +27,14 @@ import {
 } from './helper';
 import { applyPanBoundariesToOffset } from './helper/applyPanBoundariesToOffset';
 import { viewportPositionToImagePosition } from './helper/coordinateConversion';
-import { StaticPin } from './components/StaticPin';
-import { debounce } from 'lodash';
 import {
-  getBoundaryCrossedAnim,
-  getPanMomentumDecayAnim,
-  getZoomToAnimation,
-} from './animations';
+  ReactNativeZoomableViewProps,
+  ReactNativeZoomableViewState,
+  Size2D,
+  TouchPoint,
+  Vec2D,
+  ZoomableViewEvent,
+} from './typings';
 
 const initialState: ReactNativeZoomableViewState = {
   originalWidth: 0,

--- a/src/animations/index.ts
+++ b/src/animations/index.ts
@@ -1,4 +1,5 @@
 import { Animated, Easing } from 'react-native';
+
 import { Vec2D } from '../typings';
 
 export function getBoundaryCrossedAnim(

--- a/src/components/StaticPin.tsx
+++ b/src/components/StaticPin.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {
   Animated,
-  View,
-  Image,
-  StyleSheet,
   GestureResponderEvent,
-  PanResponderGestureState,
+  Image,
   PanResponder,
+  PanResponderGestureState,
+  StyleSheet,
+  View,
   ViewProps,
 } from 'react-native';
 import { Size2D } from 'src/typings';

--- a/src/debugHelper/index.tsx
+++ b/src/debugHelper/index.tsx
@@ -1,5 +1,5 @@
-import { View, StyleSheet } from 'react-native';
 import React from 'react';
+import { StyleSheet, View } from 'react-native';
 
 export const DebugTouchPoint = ({
   diameter = 20,

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -1,4 +1,5 @@
 import { GestureResponderEvent, PanResponderGestureState } from 'react-native';
+
 import { Vec2D } from '../typings';
 
 export { calcNewScaledOffsetForZoomCentering } from './calcNewScaledOffsetForZoomCentering';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,11 +10,11 @@ import type {
 } from './typings';
 
 export {
-  ReactNativeZoomableView,
-  ReactNativeZoomableViewProps,
-  ZoomableViewEvent,
   // Helper functions for coordinate conversion
   applyContainResizeMode,
   getImageOriginOnTransformSubject,
+  ReactNativeZoomableView,
+  ReactNativeZoomableViewProps,
   viewportPositionToImagePosition,
+  ZoomableViewEvent,
 };

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import {
   Animated,
   GestureResponderEvent,
@@ -5,7 +6,6 @@ import {
   PanResponderGestureState,
   ViewProps,
 } from 'react-native';
-import { ReactNode } from 'react';
 
 export enum SwipeDirection {
   SWIPE_UP = 'SWIPE_UP',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4829,6 +4829,11 @@ eslint-plugin-react@^7.30.1:
     string.prototype.matchall "^4.0.11"
     string.prototype.repeat "^1.0.0"
 
+eslint-plugin-simple-import-sort@^12.1.1:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz#e64bfdaf91c5b98a298619aa634a9f7aa43b709e"
+  integrity sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enforces import sorting via eslint-plugin-simple-import-sort and updates import order across the codebase.
> 
> - **Tooling/ESLint**:
>   - Add `eslint-plugin-simple-import-sort` and enable `simple-import-sort/imports` and `simple-import-sort/exports` rules in `package.json`.
> - **Codebase**:
>   - Reorder and group imports in `example/App.tsx`, `src/ReactNativeZoomableView.tsx`, `src/components/StaticPin.tsx`, `src/debugHelper/index.tsx`, `src/helper/index.ts`, `src/animations/index.ts`, `src/index.tsx`, and `src/typings/index.ts`.
>   - Minor export order adjustments in `src/index.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5f576e3e9b58da40b8fd8b53d5003264f23f7b9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->