### PR TITLE
runonjs

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -11,10 +11,10 @@ import {
   ViewProps,
 } from 'react-native';
 import Animated, {
-  runOnJS,
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
+import { scheduleOnRN } from 'react-native-worklets';
 
 import { applyContainResizeMode } from '../src/helper/coordinateConversion';
 import { styles } from './style';
@@ -92,7 +92,7 @@ export default function App() {
           onStaticPinPositionChange={debouncedUpdatePin}
           onStaticPinPositionMoveWorklet={(position) => {
             'worklet';
-            runOnJS(debouncedUpdateMovePin)(position);
+            scheduleOnRN(debouncedUpdateMovePin, position);
           }}
           onTransformWorklet={({ zoomLevel }) => {
             'worklet';


### PR DESCRIPTION
This is a new worklet function in Reanimated 4 that they want us to use

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the example to use the new worklet scheduling utility.
> 
> - In `example/App.tsx`, replace `runOnJS(debouncedUpdateMovePin)(position)` with `scheduleOnRN(debouncedUpdateMovePin, position)` inside `onStaticPinPositionMoveWorklet`
> - Add `scheduleOnRN` import from `react-native-worklets` and remove `runOnJS` import from `react-native-reanimated`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dae0226dc82dcef9a62c04a38c125c3cfe5c220c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->