### PR TITLE
Fix pre-existing bugs: stale closures, double-fire, zoom edge cases

### DIFF
--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -501,7 +501,7 @@ class ReactNativeZoomableView extends Component<
     }
 
     if (this.props.staticPinPosition) {
-      this._updateStaticPin();
+      this.debouncedOnStaticPinPositionChange.flush();
     }
 
     this.gestureType = null;
@@ -836,7 +836,6 @@ class ReactNativeZoomableView extends Component<
     this.offsetY = newOffsetY;
 
     this.panAnim.setValue({ x: this.offsetX, y: this.offsetY });
-    this.zoomAnim.setValue(this.zoomLevel);
 
     onShiftingAfter?.(null, null, this._getZoomableViewEventObject());
   }
@@ -996,9 +995,10 @@ class ReactNativeZoomableView extends Component<
     };
 
     // if doubleTapZoomToCenter enabled -> always zoom to center instead
+    // zoomTo uses viewport-relative coordinates where center = originalWidth/2, originalHeight/2
     if (doubleTapZoomToCenter) {
-      zoomPositionCoordinates.x = 0;
-      zoomPositionCoordinates.y = 0;
+      zoomPositionCoordinates.x = this.state.originalWidth / 2;
+      zoomPositionCoordinates.y = this.state.originalHeight / 2;
     }
 
     this.zoomTo(nextZoomStep, zoomPositionCoordinates);
@@ -1019,16 +1019,14 @@ class ReactNativeZoomableView extends Component<
     const { zoomStep, maxZoom, initialZoom } = this.props;
     const { zoomLevel } = this;
 
-    if (maxZoom == null) return;
+    if (zoomStep == null) return;
 
-    if (zoomLevel.toFixed(2) === maxZoom.toFixed(2)) {
+    if (maxZoom != null && zoomLevel.toFixed(2) === maxZoom.toFixed(2)) {
       return initialZoom;
     }
 
-    if (zoomStep == null) return;
-
     const nextZoomStep = zoomLevel * (1 + zoomStep);
-    if (nextZoomStep > maxZoom) {
+    if (maxZoom != null && nextZoomStep > maxZoom) {
       return maxZoom;
     }
 
@@ -1046,8 +1044,10 @@ class ReactNativeZoomableView extends Component<
    */
   zoomTo(newZoomLevel: number, zoomCenter?: Vec2D) {
     if (!this.props.zoomEnabled) return false;
-    if (this.props.maxZoom && newZoomLevel > this.props.maxZoom) return false;
-    if (this.props.minZoom && newZoomLevel < this.props.minZoom) return false;
+    if (this.props.maxZoom != null && newZoomLevel > this.props.maxZoom)
+      return false;
+    if (this.props.minZoom != null && newZoomLevel < this.props.minZoom)
+      return false;
 
     this.props.onZoomBefore?.(null, null, this._getZoomableViewEventObject());
 
@@ -1097,10 +1097,10 @@ class ReactNativeZoomableView extends Component<
           this.zoomToListenerId = undefined;
         }
       }
+      this.props.onZoomAfter?.(null, null, this._getZoomableViewEventObject());
     });
     // == Zoom Animation Ends ==
 
-    this.props.onZoomAfter?.(null, null, this._getZoomableViewEventObject());
     return true;
   }
 

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -1090,14 +1090,20 @@ class ReactNativeZoomableView extends Component<
 
     // == Perform Zoom Animation ==
     const listenerId = this.zoomToListenerId;
-    getZoomToAnimation(this.zoomAnim, newZoomLevel).start(() => {
+    getZoomToAnimation(this.zoomAnim, newZoomLevel).start(({ finished }) => {
       if (listenerId) {
         this.zoomAnim.removeListener(listenerId);
         if (this.zoomToListenerId === listenerId) {
           this.zoomToListenerId = undefined;
         }
       }
-      this.props.onZoomAfter?.(null, null, this._getZoomableViewEventObject());
+      if (finished) {
+        this.props.onZoomAfter?.(
+          null,
+          null,
+          this._getZoomableViewEventObject()
+        );
+      }
     });
     // == Zoom Animation Ends ==
 

--- a/src/components/StaticPin.tsx
+++ b/src/components/StaticPin.tsx
@@ -53,6 +53,10 @@ export const StaticPin = ({
   const pressDuration = longPressDuration ?? 500;
   const pressDurationRef = React.useRef(pressDuration);
   pressDurationRef.current = pressDuration;
+  const onPressRef = React.useRef(onPress);
+  onPressRef.current = onPress;
+  const onLongPressRef = React.useRef(onLongPress);
+  onLongPressRef.current = onLongPress;
   const transform = [
     { translateY: -pinSize.height },
     { translateX: -pinSize.width / 2 },
@@ -98,11 +102,11 @@ export const StaticPin = ({
           return;
         }
         const dt = Date.now() - tapTime.current;
-        if (onPress && dt < pressDurationRef.current) {
-          onPress(evt);
+        if (onPressRef.current && dt < pressDurationRef.current) {
+          onPressRef.current(evt);
         }
-        if (onLongPress && dt >= pressDurationRef.current) {
-          onLongPress(evt);
+        if (onLongPressRef.current && dt >= pressDurationRef.current) {
+          onLongPressRef.current(evt);
         }
       },
       onPanResponderTerminate: (evt, gestureState) => {


### PR DESCRIPTION
## Summary

Fixes seven pre-existing bugs found during code review of https://github.com/openspacelabs/react-native-zoomable-view/pull/149. These were all flagged as 🟣 (pre-existing) during review — bugs that existed before the strip-features PR but were surfaced by the review process.

Stacked on #149.

## Test Plan
- Set `minZoom={0}` and call `zoomTo(-1)` — confirm it's rejected (was previously allowed, causing flipped content)
- Set `maxZoom={null}` and double-tap — confirm zoom cycles between levels (was previously a silent no-op)
- Set `doubleTapZoomToCenter={true}` and double-tap — confirm zoom anchors at view center (was previously top-left)
- During a pan gesture, log `onTransform` calls — confirm one call per frame (was previously two)
- Double-tap with `staticPinPosition` set — confirm `onStaticPinPositionChange` fires once with correct post-zoom position (was previously firing twice, first with stale coords)
- Re-render StaticPin with a new `onStaticPinPress` callback, then tap — confirm new callback fires (was previously frozen at mount)

## Risk
- **`_setNewOffsetPosition` removing `zoomAnim.setValue`** — most impactful change. Consumers that accidentally relied on the double-fire (e.g., throttling that assumed 2x rate) could see different behavior. Low likelihood but worth noting.
- **`onZoomAfter` moving into animation callback** — now fires asynchronously after animation completes instead of synchronously before. Consumers that did immediate work in `onZoomAfter` assuming it fires pre-animation will see different timing.
- **`_getNextZoomStep` with `maxZoom=null`** — previously returned `undefined` (no zoom). Now allows unlimited zoom stepping. If consumers relied on `maxZoom=null` disabling double-tap, this changes behavior.

## Change details
- **Double-fire fix:** Remove redundant `zoomAnim.setValue(this.zoomLevel)` from `_setNewOffsetPosition` — zoom doesn't change during pan, so this was a no-op that triggered extra listener callbacks
- **minZoom=0 fix:** Change truthy checks (`this.props.minZoom && ...`) to null checks (`!= null`) in `zoomTo()` so `0` is treated as a valid minimum
- **maxZoom=null double-tap fix:** Move the `maxZoom == null` early return below `zoomStep` check in `_getNextZoomStep()`, and guard the comparison with `maxZoom != null`
- **doubleTapZoomToCenter fix:** Use `{x: originalWidth/2, y: originalHeight/2}` instead of `{0,0}` — the coordinate system is viewport-relative
- **onZoomAfter timing fix:** Move the `onZoomAfter` call into `getZoomToAnimation().start()` callback so `zoomLevel` reflects the completed zoom
- **Dual-path fix:** Replace immediate `_updateStaticPin()` on gesture end with `debouncedOnStaticPinPositionChange.flush()` — ensures only one callback fires with correct coordinates
- **Stale closure fix:** Add `onPressRef`/`onLongPressRef` that update on every render, read inside the frozen PanResponder closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)