### PR TITLE
Defer parent gesture activation so nested GestureDetectors in staticPinIcon can win

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -2,6 +2,7 @@ import {
   FixedSize,
   ReactNativeZoomableView,
   ReactNativeZoomableViewRef,
+  useZoomableViewParentGestureRef,
 } from '@openspacelabs/react-native-zoomable-view';
 import { debounce } from 'lodash';
 import React, { ReactNode, useMemo, useRef, useState } from 'react';
@@ -20,6 +21,7 @@ import {
   GestureHandlerRootView,
 } from 'react-native-gesture-handler';
 import Animated, {
+  SharedValue,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
@@ -37,86 +39,42 @@ const imageSize = { width: kittenSize, height: kittenSize };
 const stringifyPoint = (point?: { x: number; y: number }) =>
   point ? `${Math.round(point.x)}, ${Math.round(point.y)}` : 'Off map';
 
-const PageSheetModal = ({
-  children,
-  style,
-}: {
-  children: ReactNode;
-  style?: ViewProps['style'];
-}) => {
-  return (
-    <Modal animationType="slide" presentationStyle="pageSheet">
-      <View style={style}>{children}</View>
-    </Modal>
-  );
+const onPinLongPressJS = () => {
+  Alert.alert('Pin long-press fired');
 };
 
-export default function App() {
-  const ref = useRef<ReactNativeZoomableViewRef>(null);
-  const [showMarkers, setShowMarkers] = useState(true);
-  const [modal, setModal] = useState(false);
-  const [size, setSize] = useState<{ width: number; height: number }>({
-    width: 0,
-    height: 0,
-  });
+/**
+ * Demo pin: red main button (LongPress claims this region) and a blue knob
+ * hanging on a rail (Pan claims this region). Empty bounding-box space falls
+ * through to the parent ReactNativeZoomableView's pan/pinch.
+ *
+ * Both gestures use `.blocksExternalGesture(parentGestureRef)` so the parent
+ * FAILs while the child is active — without that, RNGH's two
+ * `GestureDetector`s run independently and both write their state, which is
+ * what causes "the canvas pans a little when I begin to drag the knob."
+ *
+ * Must be rendered INSIDE `<ReactNativeZoomableView>` so
+ * `useZoomableViewParentGestureRef()` reaches the provider.
+ */
+const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
+  const parentGestureRef = useZoomableViewParentGestureRef();
 
-  // Use layout event to get centre point, to set the pin
-  const [pin, setPin] = useState({ x: 0, y: 0 });
-
-  // Debounce the change event to avoid layout event firing too often while
-  // dragging. `useMemo` caches the debounce instance across renders so its
-  // internal timer state actually batches calls — the previous
-  // `useCallback(() => debounce(...), [])()` invoked the memoized factory
-  // on every render, producing a fresh debounce each time and defeating
-  // the debouncing entirely. `setPin` is a stable `useState` setter, so the
-  // deps array effectively never re-creates the instance.
-  const debouncedUpdatePin = useMemo(() => debounce(setPin, 10), [setPin]);
-
-  // The move event fires every frame the pin position can change. Mirror it
-  // into a SharedValue and let ReText (via `useAnimatedProps` on a wrapped
-  // TextInput) write to the native view directly on the UI thread, without
-  // ever touching JS state or the React tree.
-  const movePinShared = useSharedValue<{ x: number; y: number }>({
-    x: 0,
-    y: 0,
-  });
-  const movePinText = useDerivedValue(() => {
-    const p = movePinShared.value;
-    return `onStaticPinPositionMove: ${Math.round(p.x)}, ${Math.round(p.y)}`;
-  });
-
-  const staticPinPosition = { x: size.width / 2, y: size.height / 2 };
-  const { size: contentSize } = applyContainResizeMode(imageSize, size);
-
-  const Wrapper = modal ? PageSheetModal : View;
-
-  // Reproduce client-gesture-on-pin scenario:
-  //   - main circle: LongPress (Alert)
-  //   - knob: Pan (drags the knob visually)
-  //   - rest of the pin's bounding box: should let canvas pan through
-  // Today none of the client gestures fire because the parent GestureDetector
-  // activates on the first touch and swallows everything.
   const knobOffset = useSharedValue<{ x: number; y: number }>({ x: 0, y: 0 });
 
-  const onPinLongPressJS = () => {
-    Alert.alert('Pin long-press fired');
-  };
   const pinLongPress = useMemo(
     () =>
       Gesture.LongPress()
         .minDuration(400)
+        // The lib's parentGestureRef is typed against the lib's RNGH copy;
+        // the example consumes it via its own RNGH copy. `metro.config.js`
+        // points both at the same install at runtime, so the cast is safe.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+        .blocksExternalGesture(parentGestureRef as any)
         .onStart(() => {
           'worklet';
           runOnJS(onPinLongPressJS)();
         }),
-    []
-  );
-
-  // Counter incremented from the worklet onStart so the test can confirm the
-  // gesture fires without an Alert (Alerts steal focus mid-pan).
-  const knobPanCount = useSharedValue(0);
-  const knobPanCountText = useDerivedValue(
-    () => `knob pan starts: ${knobPanCount.value}`
+    [parentGestureRef]
   );
 
   const knobPan = useMemo(
@@ -125,6 +83,13 @@ export default function App() {
         // Generous hit slop so the small knob is easier to grab — RNGH does
         // not inflate the touch target by default.
         .hitSlop({ top: 16, bottom: 16, left: 16, right: 16 })
+        // Make the parent FAIL when this Pan activates, so the canvas does
+        // not pan while the knob is being dragged.
+        // The lib's parentGestureRef is typed against the lib's RNGH copy;
+        // the example consumes it via its own RNGH copy. `metro.config.js`
+        // points both at the same install at runtime, so the cast is safe.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+        .blocksExternalGesture(parentGestureRef as any)
         .onStart(() => {
           'worklet';
           knobPanCount.value = knobPanCount.value + 1;
@@ -137,7 +102,7 @@ export default function App() {
           'worklet';
           knobOffset.value = { x: 0, y: 0 };
         }),
-    [knobOffset, knobPanCount]
+    [knobOffset, knobPanCount, parentGestureRef]
   );
 
   const knobStyle = useAnimatedStyle(() => ({
@@ -158,13 +123,13 @@ export default function App() {
   //   • rail      left=32  top=71   34x2   → from knob right edge to pin
   //                                          left edge, at red-pin centre y
   //   • knob      left=0   top=56   32x32  → centre (16, 72), aligned w/ rail
-  const pinIcon = (
+  return (
     <View
+      pointerEvents="box-none"
       style={{
         height: 96,
         width: 180,
       }}
-      pointerEvents="box-none"
     >
       {/* Rail (decorative) */}
       <View
@@ -231,6 +196,69 @@ export default function App() {
       </GestureDetector>
     </View>
   );
+};
+
+const PageSheetModal = ({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: ViewProps['style'];
+}) => {
+  return (
+    <Modal animationType="slide" presentationStyle="pageSheet">
+      <View style={style}>{children}</View>
+    </Modal>
+  );
+};
+
+export default function App() {
+  const ref = useRef<ReactNativeZoomableViewRef>(null);
+  const [showMarkers, setShowMarkers] = useState(true);
+  const [modal, setModal] = useState(false);
+  const [size, setSize] = useState<{ width: number; height: number }>({
+    width: 0,
+    height: 0,
+  });
+
+  // Use layout event to get centre point, to set the pin
+  const [pin, setPin] = useState({ x: 0, y: 0 });
+
+  // Debounce the change event to avoid layout event firing too often while
+  // dragging. `useMemo` caches the debounce instance across renders so its
+  // internal timer state actually batches calls — the previous
+  // `useCallback(() => debounce(...), [])()` invoked the memoized factory
+  // on every render, producing a fresh debounce each time and defeating
+  // the debouncing entirely. `setPin` is a stable `useState` setter, so the
+  // deps array effectively never re-creates the instance.
+  const debouncedUpdatePin = useMemo(() => debounce(setPin, 10), [setPin]);
+
+  // The move event fires every frame the pin position can change. Mirror it
+  // into a SharedValue and let ReText (via `useAnimatedProps` on a wrapped
+  // TextInput) write to the native view directly on the UI thread, without
+  // ever touching JS state or the React tree.
+  const movePinShared = useSharedValue<{ x: number; y: number }>({
+    x: 0,
+    y: 0,
+  });
+  const movePinText = useDerivedValue(() => {
+    const p = movePinShared.value;
+    return `onStaticPinPositionMove: ${Math.round(p.x)}, ${Math.round(p.y)}`;
+  });
+
+  const staticPinPosition = { x: size.width / 2, y: size.height / 2 };
+  const { size: contentSize } = applyContainResizeMode(imageSize, size);
+
+  const Wrapper = modal ? PageSheetModal : View;
+
+  // SharedValues that need to drive UI text outside the zoom subject must be
+  // hoisted above the provider — `<DemoPin>` lives INSIDE
+  // `ReactNativeZoomableView` so it sees the parent-gesture context, but the
+  // counter text below the canvas does not.
+  const knobPanCount = useSharedValue(0);
+  const knobPanCountText = useDerivedValue(
+    () => `knob pan starts: ${knobPanCount.value}`
+  );
 
   // `GestureHandlerRootView` lives INSIDE `Wrapper` so it covers both the
   // non-modal and `Modal` (`presentationStyle="pageSheet"`) paths. `Modal`
@@ -257,7 +285,7 @@ export default function App() {
             }}
             // Where to put the pin in the content view
             staticPinPosition={staticPinPosition}
-            staticPinIcon={pinIcon}
+            staticPinIcon={<DemoPin knobPanCount={knobPanCount} />}
             // Callback that returns the position of the pin
             // on the actual source image
             onStaticPinPositionChange={debouncedUpdatePin}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -2,7 +2,9 @@ import {
   FixedSize,
   ReactNativeZoomableView,
   ReactNativeZoomableViewRef,
+  useZoomableViewContext,
   useZoomableViewParentGestureRef,
+  useZoomableViewPauseCanvas,
 } from '@openspacelabs/react-native-zoomable-view';
 import { debounce } from 'lodash';
 import React, { ReactNode, useMemo, useRef, useState } from 'react';
@@ -56,8 +58,25 @@ const onPinLongPressJS = () => {
  * Must be rendered INSIDE `<ReactNativeZoomableView>` so
  * `useZoomableViewParentGestureRef()` reaches the provider.
  */
-const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
+const DemoPin = ({
+  knobPanCount,
+  knobBeginCount,
+  knobTouchDownCount,
+  parentShiftLabel,
+}: {
+  knobPanCount: SharedValue<number>;
+  knobBeginCount: SharedValue<number>;
+  knobTouchDownCount: SharedValue<number>;
+  parentShiftLabel: SharedValue<string>;
+}) => {
   const parentGestureRef = useZoomableViewParentGestureRef();
+  const pauseCanvas = useZoomableViewPauseCanvas();
+  const ctx = useZoomableViewContext();
+  // Mirror parentShiftCount from the lib context up to the App's text below
+  // the canvas (the parent's `_handleShifting` increments it).
+  useDerivedValue(() => {
+    parentShiftLabel.value = `parent attempts:${ctx.parentShiftAttemptCount.value} writes:${ctx.parentShiftCount.value}`;
+  });
 
   const knobOffset = useSharedValue<{ x: number; y: number }>({ x: 0, y: 0 });
 
@@ -90,6 +109,20 @@ const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
         // points both at the same install at runtime, so the cast is safe.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
         .blocksExternalGesture(parentGestureRef as any)
+        // Pause the parent's canvas pan from the very first touch — runs
+        // on the UI thread before the parent's next `_handleShifting`
+        // worklet, so the canvas never drifts while the child is still in
+        // BEGAN waiting to cross its native activation threshold.
+        .onTouchesDown(() => {
+          'worklet';
+          knobTouchDownCount.value = knobTouchDownCount.value + 1;
+          pauseCanvas.value = true;
+        })
+        .onBegin(() => {
+          'worklet';
+          knobBeginCount.value = knobBeginCount.value + 1;
+          pauseCanvas.value = true;
+        })
         .onStart(() => {
           'worklet';
           knobPanCount.value = knobPanCount.value + 1;
@@ -101,8 +134,19 @@ const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
         .onEnd(() => {
           'worklet';
           knobOffset.value = { x: 0, y: 0 };
+        })
+        .onFinalize(() => {
+          'worklet';
+          pauseCanvas.value = false;
         }),
-    [knobOffset, knobPanCount, parentGestureRef]
+    [
+      knobOffset,
+      knobPanCount,
+      knobBeginCount,
+      knobTouchDownCount,
+      parentGestureRef,
+      pauseCanvas,
+    ]
   );
 
   const knobStyle = useAnimatedStyle(() => ({
@@ -112,23 +156,21 @@ const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
     ],
   }));
 
-  // Pin bounding box is 180x96. StaticPin anchors the bottom-center of this
-  // box on `staticPinPosition`, so the red pin (sitting at the box's
-  // bottom-center) has its base on the requested map point. The knob hangs
-  // to the left at the same Y as the red-pin centre, joined by a horizontal
-  // rail.
+  // Pin bounding box is 280x100. StaticPin anchors the bottom-center on
+  // `staticPinPosition`, so the red pin's tip ends on the requested map
+  // point. The knob hangs left, both bottom-aligned.
   //
   // Layout (in box coords):
-  //   • red pin   left=66  top=48   48x48  → centre (90, 72), bottom y=96
-  //   • rail      left=32  top=71   34x2   → from knob right edge to pin
-  //                                          left edge, at red-pin centre y
-  //   • knob      left=0   top=56   32x32  → centre (16, 72), aligned w/ rail
+  //   • knob      left=0    top=0    100x100 → centre (50, 50)
+  //   • red pin   left=116  top=52    48x48  → centre (140, 76), tip y=100
+  //   • rail      left=100  top=75   16x2    → at red-pin centre y, joins
+  //                                            knob right edge to pin left
   return (
     <View
       pointerEvents="box-none"
       style={{
-        height: 96,
-        width: 180,
+        height: 100,
+        width: 280,
       }}
     >
       {/* Rail (decorative) */}
@@ -137,10 +179,10 @@ const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
         style={{
           backgroundColor: 'rgba(0,0,0,0.4)',
           height: 2,
-          left: 32,
+          left: 100,
           position: 'absolute',
-          top: 71,
-          width: 34,
+          top: 75,
+          width: 16,
         }}
       />
 
@@ -149,9 +191,9 @@ const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
         <View
           style={{
             height: 48,
-            left: 66,
+            left: 116,
             position: 'absolute',
-            top: 48,
+            top: 52,
             width: 48,
           }}
         >
@@ -173,11 +215,11 @@ const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
         <Animated.View
           style={[
             {
-              height: 32,
+              height: 100,
               left: 0,
               position: 'absolute',
-              top: 56,
-              width: 32,
+              top: 0,
+              width: 100,
             },
             knobStyle,
           ]}
@@ -186,10 +228,10 @@ const DemoPin = ({ knobPanCount }: { knobPanCount: SharedValue<number> }) => {
             style={{
               backgroundColor: 'blue',
               borderColor: 'white',
-              borderRadius: 16,
+              borderRadius: 50,
               borderWidth: 2,
-              height: 32,
-              width: 32,
+              height: 100,
+              width: 100,
             }}
           />
         </Animated.View>
@@ -256,9 +298,13 @@ export default function App() {
   // `ReactNativeZoomableView` so it sees the parent-gesture context, but the
   // counter text below the canvas does not.
   const knobPanCount = useSharedValue(0);
-  const knobPanCountText = useDerivedValue(
-    () => `knob pan starts: ${knobPanCount.value}`
+  const knobBeginCount = useSharedValue(0);
+  const knobTouchDownCount = useSharedValue(0);
+  const knobLabel = useDerivedValue(
+    () =>
+      `knob touchDown:${knobTouchDownCount.value} begin:${knobBeginCount.value} start:${knobPanCount.value}`
   );
+  const parentShiftLabel = useSharedValue('parent shifts: 0');
 
   // `GestureHandlerRootView` lives INSIDE `Wrapper` so it covers both the
   // non-modal and `Modal` (`presentationStyle="pageSheet"`) paths. `Modal`
@@ -285,7 +331,14 @@ export default function App() {
             }}
             // Where to put the pin in the content view
             staticPinPosition={staticPinPosition}
-            staticPinIcon={<DemoPin knobPanCount={knobPanCount} />}
+            staticPinIcon={
+              <DemoPin
+                knobPanCount={knobPanCount}
+                knobBeginCount={knobBeginCount}
+                knobTouchDownCount={knobTouchDownCount}
+                parentShiftLabel={parentShiftLabel}
+              />
+            }
             // Callback that returns the position of the pin
             // on the actual source image
             onStaticPinPositionChange={debouncedUpdatePin}
@@ -316,7 +369,8 @@ export default function App() {
         </View>
         <Text>onStaticPinPositionChange: {stringifyPoint(pin)}</Text>
         <ReText text={movePinText} style={{ color: 'black' }} />
-        <ReText text={knobPanCountText} style={{ color: 'black' }} />
+        <ReText text={knobLabel} style={{ color: 'black' }} />
+        <ReText text={parentShiftLabel} style={{ color: 'black' }} />
         <Button
           title={`${showMarkers ? 'Hide' : 'Show'} markers`}
           onPress={() => {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -14,9 +14,18 @@ import {
   View,
   ViewProps,
 } from 'react-native';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { useDerivedValue, useSharedValue } from 'react-native-reanimated';
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+} from 'react-native-reanimated';
 import { ReText } from 'react-native-redash';
+import { runOnJS } from 'react-native-worklets';
 
 import { applyContainResizeMode } from '../src/helper/coordinateConversion';
 import { styles } from './style';
@@ -81,6 +90,148 @@ export default function App() {
 
   const Wrapper = modal ? PageSheetModal : View;
 
+  // Reproduce client-gesture-on-pin scenario:
+  //   - main circle: LongPress (Alert)
+  //   - knob: Pan (drags the knob visually)
+  //   - rest of the pin's bounding box: should let canvas pan through
+  // Today none of the client gestures fire because the parent GestureDetector
+  // activates on the first touch and swallows everything.
+  const knobOffset = useSharedValue<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  const onPinLongPressJS = () => {
+    Alert.alert('Pin long-press fired');
+  };
+  const pinLongPress = useMemo(
+    () =>
+      Gesture.LongPress()
+        .minDuration(400)
+        .onStart(() => {
+          'worklet';
+          runOnJS(onPinLongPressJS)();
+        }),
+    []
+  );
+
+  // Counter incremented from the worklet onStart so the test can confirm the
+  // gesture fires without an Alert (Alerts steal focus mid-pan).
+  const knobPanCount = useSharedValue(0);
+  const knobPanCountText = useDerivedValue(
+    () => `knob pan starts: ${knobPanCount.value}`
+  );
+
+  const knobPan = useMemo(
+    () =>
+      Gesture.Pan()
+        // Generous hit slop so the small knob is easier to grab — RNGH does
+        // not inflate the touch target by default.
+        .hitSlop({ top: 16, bottom: 16, left: 16, right: 16 })
+        .onStart(() => {
+          'worklet';
+          knobPanCount.value = knobPanCount.value + 1;
+        })
+        .onUpdate((e) => {
+          'worklet';
+          knobOffset.value = { x: e.translationX, y: e.translationY };
+        })
+        .onEnd(() => {
+          'worklet';
+          knobOffset.value = { x: 0, y: 0 };
+        }),
+    [knobOffset, knobPanCount]
+  );
+
+  const knobStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: knobOffset.value.x },
+      { translateY: knobOffset.value.y },
+    ],
+  }));
+
+  // Pin bounding box is 180x96. StaticPin anchors the bottom-center of this
+  // box on `staticPinPosition`, so the red pin (sitting at the box's
+  // bottom-center) has its base on the requested map point. The knob hangs
+  // to the left at the same Y as the red-pin centre, joined by a horizontal
+  // rail.
+  //
+  // Layout (in box coords):
+  //   • red pin   left=66  top=48   48x48  → centre (90, 72), bottom y=96
+  //   • rail      left=32  top=71   34x2   → from knob right edge to pin
+  //                                          left edge, at red-pin centre y
+  //   • knob      left=0   top=56   32x32  → centre (16, 72), aligned w/ rail
+  const pinIcon = (
+    <View
+      style={{
+        height: 96,
+        width: 180,
+      }}
+      pointerEvents="box-none"
+    >
+      {/* Rail (decorative) */}
+      <View
+        pointerEvents="none"
+        style={{
+          backgroundColor: 'rgba(0,0,0,0.4)',
+          height: 2,
+          left: 32,
+          position: 'absolute',
+          top: 71,
+          width: 34,
+        }}
+      />
+
+      {/* Main pin — LongPress claims this region */}
+      <GestureDetector gesture={pinLongPress}>
+        <View
+          style={{
+            height: 48,
+            left: 66,
+            position: 'absolute',
+            top: 48,
+            width: 48,
+          }}
+        >
+          <View
+            style={{
+              backgroundColor: 'red',
+              borderColor: 'white',
+              borderRadius: 24,
+              borderWidth: 2,
+              height: 48,
+              width: 48,
+            }}
+          />
+        </View>
+      </GestureDetector>
+
+      {/* Knob — Pan claims this region */}
+      <GestureDetector gesture={knobPan}>
+        <Animated.View
+          style={[
+            {
+              height: 32,
+              left: 0,
+              position: 'absolute',
+              top: 56,
+              width: 32,
+            },
+            knobStyle,
+          ]}
+        >
+          <View
+            style={{
+              backgroundColor: 'blue',
+              borderColor: 'white',
+              borderRadius: 16,
+              borderWidth: 2,
+              height: 32,
+              width: 32,
+            }}
+          />
+        </Animated.View>
+      </GestureDetector>
+    </View>
+  );
+
   // `GestureHandlerRootView` lives INSIDE `Wrapper` so it covers both the
   // non-modal and `Modal` (`presentationStyle="pageSheet"`) paths. `Modal`
   // renders in a separate native window, so an outer root view above
@@ -106,6 +257,7 @@ export default function App() {
             }}
             // Where to put the pin in the content view
             staticPinPosition={staticPinPosition}
+            staticPinIcon={pinIcon}
             // Callback that returns the position of the pin
             // on the actual source image
             onStaticPinPositionChange={debouncedUpdatePin}
@@ -136,6 +288,7 @@ export default function App() {
         </View>
         <Text>onStaticPinPositionChange: {stringifyPoint(pin)}</Text>
         <ReText text={movePinText} style={{ color: 'black' }} />
+        <ReText text={knobPanCountText} style={{ color: 'black' }} />
         <Button
           title={`${showMarkers ? 'Hide' : 'Show'} markers`}
           onPress={() => {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -3,8 +3,6 @@ import {
   ReactNativeZoomableView,
   ReactNativeZoomableViewRef,
   useZoomableViewContext,
-  useZoomableViewParentGestureRef,
-  useZoomableViewPauseCanvas,
 } from '@openspacelabs/react-native-zoomable-view';
 import { debounce } from 'lodash';
 import React, { ReactNode, useMemo, useRef, useState } from 'react';
@@ -23,7 +21,6 @@ import {
   GestureHandlerRootView,
 } from 'react-native-gesture-handler';
 import Animated, {
-  SharedValue,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
@@ -58,25 +55,8 @@ const onPinLongPressJS = () => {
  * Must be rendered INSIDE `<ReactNativeZoomableView>` so
  * `useZoomableViewParentGestureRef()` reaches the provider.
  */
-const DemoPin = ({
-  knobPanCount,
-  knobBeginCount,
-  knobTouchDownCount,
-  parentShiftLabel,
-}: {
-  knobPanCount: SharedValue<number>;
-  knobBeginCount: SharedValue<number>;
-  knobTouchDownCount: SharedValue<number>;
-  parentShiftLabel: SharedValue<string>;
-}) => {
-  const parentGestureRef = useZoomableViewParentGestureRef();
-  const pauseCanvas = useZoomableViewPauseCanvas();
-  const ctx = useZoomableViewContext();
-  // Mirror parentShiftCount from the lib context up to the App's text below
-  // the canvas (the parent's `_handleShifting` increments it).
-  useDerivedValue(() => {
-    parentShiftLabel.value = `parent attempts:${ctx.parentShiftAttemptCount.value} writes:${ctx.parentShiftCount.value}`;
-  });
+const DemoPin = () => {
+  const { pauseCanvas } = useZoomableViewContext();
 
   const knobOffset = useSharedValue<{ x: number; y: number }>({ x: 0, y: 0 });
 
@@ -84,16 +64,19 @@ const DemoPin = ({
     () =>
       Gesture.LongPress()
         .minDuration(400)
-        // The lib's parentGestureRef is typed against the lib's RNGH copy;
-        // the example consumes it via its own RNGH copy. `metro.config.js`
-        // points both at the same install at runtime, so the cast is safe.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        .blocksExternalGesture(parentGestureRef as any)
+        .onTouchesDown(() => {
+          'worklet';
+          pauseCanvas.value = true;
+        })
         .onStart(() => {
           'worklet';
           runOnJS(onPinLongPressJS)();
+        })
+        .onFinalize(() => {
+          'worklet';
+          pauseCanvas.value = false;
         }),
-    [parentGestureRef]
+    [pauseCanvas]
   );
 
   const knobPan = useMemo(
@@ -102,30 +85,14 @@ const DemoPin = ({
         // Generous hit slop so the small knob is easier to grab — RNGH does
         // not inflate the touch target by default.
         .hitSlop({ top: 16, bottom: 16, left: 16, right: 16 })
-        // Make the parent FAIL when this Pan activates, so the canvas does
-        // not pan while the knob is being dragged.
-        // The lib's parentGestureRef is typed against the lib's RNGH copy;
-        // the example consumes it via its own RNGH copy. `metro.config.js`
-        // points both at the same install at runtime, so the cast is safe.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        .blocksExternalGesture(parentGestureRef as any)
-        // Pause the parent's canvas pan from the very first touch — runs
-        // on the UI thread before the parent's next `_handleShifting`
-        // worklet, so the canvas never drifts while the child is still in
-        // BEGAN waiting to cross its native activation threshold.
+        // Pause the parent's canvas pan from the very first touch.
+        // Both worklets run on the UI thread in the same JS context, so
+        // the parent's next `_handleShifting` reads the latest value with
+        // zero dispatch latency — canvas never drifts while the child is
+        // still in BEGAN waiting to cross its native activation threshold.
         .onTouchesDown(() => {
           'worklet';
-          knobTouchDownCount.value = knobTouchDownCount.value + 1;
           pauseCanvas.value = true;
-        })
-        .onBegin(() => {
-          'worklet';
-          knobBeginCount.value = knobBeginCount.value + 1;
-          pauseCanvas.value = true;
-        })
-        .onStart(() => {
-          'worklet';
-          knobPanCount.value = knobPanCount.value + 1;
         })
         .onUpdate((e) => {
           'worklet';
@@ -139,14 +106,7 @@ const DemoPin = ({
           'worklet';
           pauseCanvas.value = false;
         }),
-    [
-      knobOffset,
-      knobPanCount,
-      knobBeginCount,
-      knobTouchDownCount,
-      parentGestureRef,
-      pauseCanvas,
-    ]
+    [knobOffset, pauseCanvas]
   );
 
   const knobStyle = useAnimatedStyle(() => ({
@@ -293,19 +253,6 @@ export default function App() {
 
   const Wrapper = modal ? PageSheetModal : View;
 
-  // SharedValues that need to drive UI text outside the zoom subject must be
-  // hoisted above the provider — `<DemoPin>` lives INSIDE
-  // `ReactNativeZoomableView` so it sees the parent-gesture context, but the
-  // counter text below the canvas does not.
-  const knobPanCount = useSharedValue(0);
-  const knobBeginCount = useSharedValue(0);
-  const knobTouchDownCount = useSharedValue(0);
-  const knobLabel = useDerivedValue(
-    () =>
-      `knob touchDown:${knobTouchDownCount.value} begin:${knobBeginCount.value} start:${knobPanCount.value}`
-  );
-  const parentShiftLabel = useSharedValue('parent shifts: 0');
-
   // `GestureHandlerRootView` lives INSIDE `Wrapper` so it covers both the
   // non-modal and `Modal` (`presentationStyle="pageSheet"`) paths. `Modal`
   // renders in a separate native window, so an outer root view above
@@ -331,14 +278,7 @@ export default function App() {
             }}
             // Where to put the pin in the content view
             staticPinPosition={staticPinPosition}
-            staticPinIcon={
-              <DemoPin
-                knobPanCount={knobPanCount}
-                knobBeginCount={knobBeginCount}
-                knobTouchDownCount={knobTouchDownCount}
-                parentShiftLabel={parentShiftLabel}
-              />
-            }
+            staticPinIcon={<DemoPin />}
             // Callback that returns the position of the pin
             // on the actual source image
             onStaticPinPositionChange={debouncedUpdatePin}
@@ -369,8 +309,6 @@ export default function App() {
         </View>
         <Text>onStaticPinPositionChange: {stringifyPoint(pin)}</Text>
         <ReText text={movePinText} style={{ color: 'black' }} />
-        <ReText text={knobLabel} style={{ color: 'black' }} />
-        <ReText text={parentShiftLabel} style={{ color: 'black' }} />
         <Button
           title={`${showMarkers ? 'Hide' : 'Show'} markers`}
           onPress={() => {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -43,17 +43,15 @@ const onPinLongPressJS = () => {
 };
 
 /**
- * Demo pin: red main button (LongPress claims this region) and a blue knob
- * hanging on a rail (Pan claims this region). Empty bounding-box space falls
- * through to the parent ReactNativeZoomableView's pan/pinch.
+ * Demo pin: red main button (`Gesture.LongPress` claims this region) and a
+ * blue knob hanging on a rail (`Gesture.Pan` claims this region). Empty
+ * bounding-box space falls through to the ZoomableView's own pan/pinch.
  *
- * Both gestures use `.blocksExternalGesture(parentGestureRef)` so the parent
- * FAILs while the child is active — without that, RNGH's two
- * `GestureDetector`s run independently and both write their state, which is
- * what causes "the canvas pans a little when I begin to drag the knob."
- *
- * Must be rendered INSIDE `<ReactNativeZoomableView>` so
- * `useZoomableViewParentGestureRef()` reaches the provider.
+ * Both gestures toggle `pauseCanvas` (from the ZoomableView context) so
+ * the ZoomableView's own pan/long-press/tap handling skips the touch
+ * while the consumer's gesture is active. Must be rendered INSIDE
+ * `<ReactNativeZoomableView>` so `useZoomableViewContext()` reaches the
+ * provider.
  */
 const DemoPin = () => {
   const { pauseCanvas } = useZoomableViewContext();
@@ -85,11 +83,12 @@ const DemoPin = () => {
         // Generous hit slop so the small knob is easier to grab — RNGH does
         // not inflate the touch target by default.
         .hitSlop({ top: 16, bottom: 16, left: 16, right: 16 })
-        // Pause the parent's canvas pan from the very first touch.
-        // Both worklets run on the UI thread in the same JS context, so
-        // the parent's next `_handleShifting` reads the latest value with
-        // zero dispatch latency — canvas never drifts while the child is
-        // still in BEGAN waiting to cross its native activation threshold.
+        // Pause the ZoomableView's own pan/long-press/tap handling from
+        // the very first touch. Both worklets run on the UI thread in
+        // the same JS context, so the ZoomableView's next gesture
+        // callback reads the latest value synchronously — canvas never
+        // drifts while this Pan is still in BEGAN waiting to cross its
+        // native activation threshold.
         .onTouchesDown(() => {
           'worklet';
           pauseCanvas.value = true;

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -13,7 +13,6 @@ import {
   GestureDetector,
   GestureTouchEvent,
 } from 'react-native-gesture-handler';
-import type { GestureStateManagerType } from 'react-native-gesture-handler/lib/typescript/handlers/gestures/gestureStateManager';
 import Animated, {
   cancelAnimation,
   runOnJS,
@@ -185,17 +184,6 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   const lastGestureCenterPosition = useSharedValue<Vec2D | null>(null);
   const lastGestureTouchDistance = useSharedValue<number | null>(150);
   const gestureStarted = useSharedValue(false);
-  // Tracks whether the parent gesture has claimed the touch (transitioned to
-  // ACTIVE on the RNGH state machine). Stays `false` while the parent is
-  // still in BEGAN, so nested child `GestureDetector`s placed inside
-  // `staticPinIcon` (or anywhere inside the zoom subject) get RNGH's default
-  // window to activate first. Until activation, `_handleShifting` /
-  // `_handlePinching` skip their offset writes so the canvas does not
-  // creep during the first ~10 pixels of a pan that a child gesture is
-  // about to claim. Activation triggers (set inside the manual gesture
-  // callbacks): 2nd finger touches down, 1-finger movement crosses
-  // `ACTIVATION_PX`, or the long-press timer fires. Reset in `onFinalize`.
-  const parentActivated = useSharedValue(false);
   // UI-thread synchronous "pause canvas" flag. Consumers nesting their own
   // gesture inside `staticPinIcon` can set this `true` from the very first
   // touch worklet (`onTouchesDown` / `onBegin`) so the parent skips canvas
@@ -769,14 +757,6 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     if (!isMounted.current) return;
     if (props.onLongPress && props.longPressDuration) {
       longPressTimeout.value = setTimeout(() => {
-        // Suppress when a consumer's nested gesture has paused the parent
-        // (`pauseCanvas`). Without this gate the parent's prop `onLongPress`
-        // would fire alongside the consumer's own LongPress 700ms into the
-        // gesture, producing two callbacks for one touch.
-        if (pauseCanvas.value) {
-          longPressTimeout.value = undefined;
-          return;
-        }
         // Invoke the stable `onLongPress` wrapper rather than the captured
         // `props.onLongPress` — the closure was captured at schedule time and
         // would fire a stale callback if the parent re-rendered during the
@@ -1035,13 +1015,6 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     });
     if (!shift) return;
 
-    // Synchronous UI-thread pause flag. A consumer's nested gesture sets
-    // this `true` from its first-touch worklet (`onTouchesDown`/`onBegin`)
-    // — that worklet runs on the UI thread before the parent's next
-    // `_handleShifting` worklet, so the parent reads the latest value with
-    // zero dispatch latency and skips its offset write.
-    if (pauseCanvas.value) return;
-
     const newOffsetX = offsetX.value + shift.x;
     const newOffsetY = offsetY.value + shift.y;
 
@@ -1150,10 +1123,6 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   const _resolveAndHandleTap = (e: GestureTouchEvent) => {
     // Post-unmount runOnJS guard; see `isMounted` declaration.
     if (!isMounted.current) return;
-    // Skip tap classification when a consumer's nested gesture paused the
-    // parent — otherwise the release of a touch a child handler claimed
-    // would fire a phantom `onSingleTap`/`onDoubleTap` on the canvas.
-    if (pauseCanvas.value) return;
     const now = Date.now();
     if (
       doubleTapFirstTapReleaseTimestamp.value &&
@@ -1576,15 +1545,16 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   };
 
   const firstTouch = useSharedValue<Vec2D | undefined>(undefined);
-  const activateIfNeeded = (stateManager: GestureStateManagerType) => {
-    'worklet';
-    if (!parentActivated.value) {
-      stateManager.activate();
-      parentActivated.value = true;
-    }
-  };
+  // While `pauseCanvas.value` is true (set by a consumer's nested gesture
+  // from its `onTouchesDown` worklet), the parent's manual gesture
+  // short-circuits all lifecycle handlers: no grant (long-press timer
+  // never armed), no move (no offset writes, no consumer move callback),
+  // no tap classification on release. The RNGH state machine still ends
+  // cleanly via `stateManager.end()` — only consumer-visible parent
+  // behaviors are suppressed.
   const gesture = Gesture.Manual()
     .onTouchesDown((e, stateManager) => {
+      if (pauseCanvas.value) return;
       if (!firstTouch.value) {
         // Parent only goes BEGAN — not ACTIVE. ACTIVE on touch-down would
         // claim exclusive RNGH ownership of the touch and cancel any nested
@@ -1612,7 +1582,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
         // earlier started competing for the 1st finger — child gestures
         // inside `staticPinIcon` are expected to be single-touch (tap, long
         // press, drag); a 2-finger session is the parent's domain.
-        activateIfNeeded(stateManager);
+        stateManager.activate();
         // Long-press is a single-finger gesture — disarm any armed timer.
         // Safe no-op if the simultaneous-case long-press gate in
         // `_handlePanResponderGrant` already prevented arming.
@@ -1646,56 +1616,31 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
       }
     })
     .onTouchesMove((e, stateManager) => {
+      if (pauseCanvas.value) return;
       const dx = e.allTouches[0].x - (firstTouch.value?.x || 0);
       const dy = e.allTouches[0].y - (firstTouch.value?.y || 0);
-      // Earn the gesture: once the user crosses the activation threshold
-      // (or has 2 fingers down), this is unambiguously a pan/pinch and the
-      // parent claims the touch. Below threshold the parent stays BEGAN so
-      // any nested child gesture (LongPress, Tap, Pan, Rotation, etc.) has
-      // a wide enough window to activate first.
-      //
-      // The threshold has to be large enough that a child Pan (which uses
-      // `.blocksExternalGesture(parentGestureRef)` to FAIL the parent on
-      // child activation) gets there first — otherwise the parent activates
-      // first and writes one or more frames of canvas pan before being
-      // blocked. Empirically with the default RN Pan minDistance of 0 plus
-      // iOS native slop, child Pan reliably activates well under 30 px;
-      // anything below ~25 px lets the parent slip in a frame of writes.
-      // 30 px is conservative — `_handleShifting` is also gated by
-      // `parentActivated`, so off-pin canvas pan kicks in cleanly the
-      // moment the threshold is crossed (no creep, no jump).
-      // Activate ONLY for multi-finger (pinch is unambiguous and the parent
-      // must own it). 1-finger moves stay BEGAN — `blocksExternalGesture`
-      // from any nested child gesture is what cancels the parent at the
-      // RNGH tree level. Canvas-pan suppression while a child is in BEGAN
-      // (before its native activation) is handled by the synchronous
-      // `pauseCanvas` SharedValue — see `_handleShifting`.
+      // 1-finger moves stay BEGAN. Multi-finger is unambiguous pinch and
+      // the parent must own it.
       if (e.numberOfTouches >= 2) {
-        activateIfNeeded(stateManager);
+        stateManager.activate();
       }
       _handlePanResponderMove(e, { dx, dy });
     })
     .onTouchesUp((e, stateManager) => {
-      // only end if this is the last touch being lifted
+      // Always end the RNGH state machine on the final release so the
+      // gesture cycle terminates cleanly, but suppress consumer callbacks
+      // and tap classification when paused.
       if (e.numberOfTouches === 0) {
-        // Genuine touch release — `wasReleased=true` enables tap
-        // classification (single/double/long press resolution).
-        _handlePanResponderEnd(e, true);
+        if (!pauseCanvas.value) _handlePanResponderEnd(e, true);
         stateManager.end();
       }
     })
     .onTouchesCancelled((e, stateManager) => {
-      // RNGH cancellation — gesture aborted, not released. Pass
-      // `wasReleased=false` so this path does not produce a spurious
-      // `onSingleTap`, and `isCancellation=true` so the terminate callback
-      // is queued from inside `_handlePanResponderEnd` (before the terminal
-      // mirror reset) — see the JSDoc on `_handlePanResponderEnd` for why.
-      _handlePanResponderEnd(e, false, true);
+      if (!pauseCanvas.value) _handlePanResponderEnd(e, false, true);
       stateManager.end();
     })
     .onFinalize(() => {
       firstTouch.value = undefined;
-      parentActivated.value = false;
     });
 
   const transformStyle = useAnimatedStyle(() => {

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from 'react';
 import { StyleSheet, View } from 'react-native';
+import type { GestureType } from 'react-native-gesture-handler';
 import {
   Gesture,
   GestureDetector,
@@ -1563,7 +1564,15 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
       parentActivated.value = true;
     }
   };
+  // Stable RNGH ref so consumers nesting their own GestureDetector inside
+  // `staticPinIcon` (or anywhere inside the zoom subject) can give their
+  // gesture priority via `myGesture.blocksExternalGesture(parentGestureRef)`.
+  // Without that composition, RNGH does NOT auto-coordinate across nested
+  // `GestureDetector` boundaries — both the parent and the child run, and
+  // both write their state.
+  const parentGestureRef = useRef<GestureType | undefined>(undefined);
   const gesture = Gesture.Manual()
+    .withRef(parentGestureRef)
     .onTouchesDown((e, stateManager) => {
       if (!firstTouch.value) {
         // Parent only goes BEGAN — not ACTIVE. ACTIVE on touch-down would
@@ -1687,7 +1696,14 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
 
   return (
     <ReactNativeZoomableViewProvider
-      value={{ zoom, inverseZoom, inverseZoomStyle, offsetX, offsetY }}
+      value={{
+        zoom,
+        inverseZoom,
+        inverseZoomStyle,
+        offsetX,
+        offsetY,
+        parentGestureRef,
+      }}
     >
       <GestureDetector gesture={gesture}>
         <View

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -8,7 +8,6 @@ import React, {
   useState,
 } from 'react';
 import { StyleSheet, View } from 'react-native';
-import type { GestureType } from 'react-native-gesture-handler';
 import {
   Gesture,
   GestureDetector,
@@ -209,14 +208,6 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   // Exposed via `useZoomableViewPauseCanvas()`. Consumers reset it on
   // their gesture's `onEnd` / `onFinalize`.
   const pauseCanvas = useSharedValue(false);
-  // Debug counters: `parentShiftAttemptCount` increments on every
-  // `_handleShifting` call past its panEnabled / shift-validity checks
-  // (i.e. every frame the parent would have written if not suppressed);
-  // `parentShiftCount` increments only on actual offset writes (after the
-  // `pauseCanvas` gate). The two together let the example distinguish
-  // "child suppressed the parent" from "parent never had touches".
-  const parentShiftAttemptCount = useSharedValue(0);
-  const parentShiftCount = useSharedValue(0);
   // JS-thread mirror of `gestureStarted` exposed via the imperative handle.
   // The UI-thread `gestureStarted` SharedValue must reset synchronously at
   // the end of `_handlePanResponderEnd` so subsequent `onTouchesMove`
@@ -778,6 +769,14 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     if (!isMounted.current) return;
     if (props.onLongPress && props.longPressDuration) {
       longPressTimeout.value = setTimeout(() => {
+        // Suppress when a consumer's nested gesture has paused the parent
+        // (`pauseCanvas`). Without this gate the parent's prop `onLongPress`
+        // would fire alongside the consumer's own LongPress 700ms into the
+        // gesture, producing two callbacks for one touch.
+        if (pauseCanvas.value) {
+          longPressTimeout.value = undefined;
+          return;
+        }
         // Invoke the stable `onLongPress` wrapper rather than the captured
         // `props.onLongPress` — the closure was captured at schedule time and
         // would fire a stale callback if the parent re-rendered during the
@@ -1036,26 +1035,12 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     });
     if (!shift) return;
 
-    // Debug: count attempts (every _handleShifting call past the panEnabled
-    // / shift-validity checks) regardless of whether the pause/gate skips
-    // the write. Lets the example surface "parent tried to write but was
-    // suppressed" vs "parent actually wrote".
-    parentShiftAttemptCount.value = parentShiftAttemptCount.value + 1;
-
     // Synchronous UI-thread pause flag. A consumer's nested gesture sets
-    // this `true` from its `onTouchesDown` / `onBegin` worklet — that
-    // worklet runs on the UI thread before the parent's next
+    // this `true` from its first-touch worklet (`onTouchesDown`/`onBegin`)
+    // — that worklet runs on the UI thread before the parent's next
     // `_handleShifting` worklet, so the parent reads the latest value with
-    // zero dispatch latency and skips its offset write. RNGH's cross-detector
-    // cancel via `.blocksExternalGesture(parentGestureRef)` is what
-    // ultimately ends the parent gesture, but it arrives 1-N frames after
-    // the child finally activates; this flag closes the window where the
-    // child is still in BEGAN and the parent is still the sole handler
-    // writing to the canvas.
+    // zero dispatch latency and skips its offset write.
     if (pauseCanvas.value) return;
-
-    // Debug: count parent shifts that actually wrote offsets.
-    parentShiftCount.value = parentShiftCount.value + 1;
 
     const newOffsetX = offsetX.value + shift.x;
     const newOffsetY = offsetY.value + shift.y;
@@ -1165,6 +1150,10 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   const _resolveAndHandleTap = (e: GestureTouchEvent) => {
     // Post-unmount runOnJS guard; see `isMounted` declaration.
     if (!isMounted.current) return;
+    // Skip tap classification when a consumer's nested gesture paused the
+    // parent — otherwise the release of a touch a child handler claimed
+    // would fire a phantom `onSingleTap`/`onDoubleTap` on the canvas.
+    if (pauseCanvas.value) return;
     const now = Date.now();
     if (
       doubleTapFirstTapReleaseTimestamp.value &&
@@ -1594,15 +1583,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
       parentActivated.value = true;
     }
   };
-  // Stable RNGH ref so consumers nesting their own GestureDetector inside
-  // `staticPinIcon` (or anywhere inside the zoom subject) can give their
-  // gesture priority via `myGesture.blocksExternalGesture(parentGestureRef)`.
-  // Without that composition, RNGH does NOT auto-coordinate across nested
-  // `GestureDetector` boundaries — both the parent and the child run, and
-  // both write their state.
-  const parentGestureRef = useRef<GestureType | undefined>(undefined);
   const gesture = Gesture.Manual()
-    .withRef(parentGestureRef)
     .onTouchesDown((e, stateManager) => {
       if (!firstTouch.value) {
         // Parent only goes BEGAN — not ACTIVE. ACTIVE on touch-down would
@@ -1738,9 +1719,6 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
         inverseZoomStyle,
         offsetX,
         offsetY,
-        parentGestureRef,
-        parentShiftCount,
-        parentShiftAttemptCount,
         pauseCanvas,
       }}
     >

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -13,6 +13,7 @@ import {
   GestureDetector,
   GestureTouchEvent,
 } from 'react-native-gesture-handler';
+import type { GestureStateManagerType } from 'react-native-gesture-handler/lib/typescript/handlers/gestures/gestureStateManager';
 import Animated, {
   cancelAnimation,
   runOnJS,
@@ -184,6 +185,17 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   const lastGestureCenterPosition = useSharedValue<Vec2D | null>(null);
   const lastGestureTouchDistance = useSharedValue<number | null>(150);
   const gestureStarted = useSharedValue(false);
+  // Tracks whether the parent gesture has claimed the touch (transitioned to
+  // ACTIVE on the RNGH state machine). Stays `false` while the parent is
+  // still in BEGAN, so nested child `GestureDetector`s placed inside
+  // `staticPinIcon` (or anywhere inside the zoom subject) get RNGH's default
+  // window to activate first. Until activation, `_handleShifting` /
+  // `_handlePinching` skip their offset writes so the canvas does not
+  // creep during the first ~10 pixels of a pan that a child gesture is
+  // about to claim. Activation triggers (set inside the manual gesture
+  // callbacks): 2nd finger touches down, 1-finger movement crosses
+  // `ACTIVATION_PX`, or the long-press timer fires. Reset in `onFinalize`.
+  const parentActivated = useSharedValue(false);
   // JS-thread mirror of `gestureStarted` exposed via the imperative handle.
   // The UI-thread `gestureStarted` SharedValue must reset synchronously at
   // the end of `_handlePanResponderEnd` so subsequent `onTouchesMove`
@@ -1003,6 +1015,17 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     });
     if (!shift) return;
 
+    // Until the parent gesture has earned the touch (movement past the
+    // activation threshold, 2nd finger, or long-press), suppress the
+    // offset write. `_calcOffsetShiftSinceLastGestureState` above has
+    // already advanced `lastGestureCenterPosition` to the current point,
+    // so the first shift after activation produces a single-frame delta
+    // — no visual jump from the touch-down point to where the finger is
+    // when parent activates. This is what stops the canvas from "creeping"
+    // during the first ~10 pixels of a knob/pin pan that a child gesture
+    // is about to claim.
+    if (!parentActivated.value) return;
+
     const newOffsetX = offsetX.value + shift.x;
     const newOffsetY = offsetY.value + shift.y;
 
@@ -1533,15 +1556,23 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   };
 
   const firstTouch = useSharedValue<Vec2D | undefined>(undefined);
+  const activateIfNeeded = (stateManager: GestureStateManagerType) => {
+    'worklet';
+    if (!parentActivated.value) {
+      stateManager.activate();
+      parentActivated.value = true;
+    }
+  };
   const gesture = Gesture.Manual()
     .onTouchesDown((e, stateManager) => {
       if (!firstTouch.value) {
-        // RNGH state machine order: UNDETERMINED → BEGAN (begin) → ACTIVE
-        // (activate). Calling activate() first relies on activate's force-true
-        // path to jump straight to ACTIVE, which makes the subsequent begin()
-        // a no-op (ACTIVE cannot regress to BEGAN).
+        // Parent only goes BEGAN — not ACTIVE. ACTIVE on touch-down would
+        // claim exclusive RNGH ownership of the touch and cancel any nested
+        // child gesture (LongPress, Pan, etc.) inside `staticPinIcon` before
+        // it had a chance to activate. Children get RNGH's default
+        // child-priority window; parent activates later if/when it earns the
+        // gesture (movement threshold, 2nd finger, or long-press timer).
         stateManager.begin();
-        stateManager.activate();
         firstTouch.value = { x: e.allTouches[0].x, y: e.allTouches[0].y };
         _handlePanResponderGrant(e);
       }
@@ -1556,6 +1587,12 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
       // future additions) had to be re-mirrored into both branches and
       // reviewers kept finding gaps.
       if (e.numberOfTouches >= 2) {
+        // Pinch is unambiguous from the moment the 2nd finger lands. Claim
+        // the touch now so the parent owns the pinch even if a child gesture
+        // earlier started competing for the 1st finger — child gestures
+        // inside `staticPinIcon` are expected to be single-touch (tap, long
+        // press, drag); a 2-finger session is the parent's domain.
+        activateIfNeeded(stateManager);
         // Long-press is a single-finger gesture — disarm any armed timer.
         // Safe no-op if the simultaneous-case long-press gate in
         // `_handlePanResponderGrant` already prevented arming.
@@ -1588,9 +1625,28 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
         lastGestureCenterPosition.value = null;
       }
     })
-    .onTouchesMove((e) => {
+    .onTouchesMove((e, stateManager) => {
       const dx = e.allTouches[0].x - (firstTouch.value?.x || 0);
       const dy = e.allTouches[0].y - (firstTouch.value?.y || 0);
+      // Earn the gesture: once the user crosses ~10px of movement (or has
+      // 2 fingers down), this is unambiguously a pan/pinch and the parent
+      // claims the touch. Below threshold the parent stays BEGAN so any
+      // nested child gesture (LongPress, Tap, Pan with default minDistance,
+      // etc.) has a wide enough window to activate first. The threshold is
+      // intentionally larger than the 2px shift-detection threshold used by
+      // `_handlePanResponderMove` for `gestureType='shift'` classification:
+      // shift classification gates internal panning math, while activation
+      // gates RNGH ownership of the touch — the latter needs slack so brief
+      // jitter at the start of a child Pan does not wrest the touch from
+      // the child before its own minDistance fires.
+      const ACTIVATION_PX = 10;
+      if (
+        e.numberOfTouches >= 2 ||
+        Math.abs(dx) > ACTIVATION_PX ||
+        Math.abs(dy) > ACTIVATION_PX
+      ) {
+        activateIfNeeded(stateManager);
+      }
       _handlePanResponderMove(e, { dx, dy });
     })
     .onTouchesUp((e, stateManager) => {
@@ -1613,6 +1669,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     })
     .onFinalize(() => {
       firstTouch.value = undefined;
+      parentActivated.value = false;
     });
 
   const transformStyle = useAnimatedStyle(() => {

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -184,17 +184,16 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   const lastGestureCenterPosition = useSharedValue<Vec2D | null>(null);
   const lastGestureTouchDistance = useSharedValue<number | null>(150);
   const gestureStarted = useSharedValue(false);
-  // UI-thread synchronous "pause canvas" flag. Consumers nesting their own
-  // gesture inside `staticPinIcon` can set this `true` from the very first
-  // touch worklet (`onTouchesDown` / `onBegin`) so the parent skips canvas
-  // offset writes from frame 1. Both worklets run on the UI thread in the
-  // same JS context, so the parent reads the latest value with zero
-  // dispatch latency — closing the leak window where RNGH's cross-detector
-  // cancel via `.blocksExternalGesture(parentGestureRef)` had not yet
-  // arrived but the child gesture was still in BEGAN (so its `onUpdate`
-  // hadn't fired and the parent was the only handler writing state).
-  // Exposed via `useZoomableViewPauseCanvas()`. Consumers reset it on
-  // their gesture's `onEnd` / `onFinalize`.
+  // UI-thread synchronous "pause this ZoomableView" flag. Consumers nesting
+  // their own gesture inside `staticPinIcon` set this `true` from their
+  // gesture's first-touch worklet (`onTouchesDown` / `onBegin`) so the
+  // ZoomableView's own pan/pinch/tap/long-press handling skips the touch
+  // from frame 1. Both worklets run on the same UI thread JS context, so
+  // the read in this component's gesture callbacks is synchronous —
+  // closing the window where RNGH's cross-detector cancel hasn't yet
+  // arrived but the consumer's gesture is still in BEGAN (its `onUpdate`
+  // hasn't fired). Exposed on the ZoomableView context. Consumers reset
+  // it on their gesture's `onFinalize`.
   const pauseCanvas = useSharedValue(false);
   // JS-thread mirror of `gestureStarted` exposed via the imperative handle.
   // The UI-thread `gestureStarted` SharedValue must reset synchronously at
@@ -1546,22 +1545,21 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
 
   const firstTouch = useSharedValue<Vec2D | undefined>(undefined);
   // While `pauseCanvas.value` is true (set by a consumer's nested gesture
-  // from its `onTouchesDown` worklet), the parent's manual gesture
-  // short-circuits all lifecycle handlers: no grant (long-press timer
-  // never armed), no move (no offset writes, no consumer move callback),
-  // no tap classification on release. The RNGH state machine still ends
-  // cleanly via `stateManager.end()` — only consumer-visible parent
+  // from its `onTouchesDown` worklet), this gesture short-circuits all
+  // lifecycle handlers: no grant (long-press timer never armed), no move
+  // (no offset writes, no consumer move callback), no tap classification
+  // on release. The RNGH state machine still ends cleanly via
+  // `stateManager.end()` — only the ZoomableView's own consumer-visible
   // behaviors are suppressed.
   const gesture = Gesture.Manual()
     .onTouchesDown((e, stateManager) => {
       if (pauseCanvas.value) return;
       if (!firstTouch.value) {
-        // Parent only goes BEGAN — not ACTIVE. ACTIVE on touch-down would
-        // claim exclusive RNGH ownership of the touch and cancel any nested
-        // child gesture (LongPress, Pan, etc.) inside `staticPinIcon` before
-        // it had a chance to activate. Children get RNGH's default
-        // child-priority window; parent activates later if/when it earns the
-        // gesture (movement threshold, 2nd finger, or long-press timer).
+        // Stay in BEGAN on touch-down. Going straight to ACTIVE would
+        // claim exclusive RNGH ownership of the touch and cancel any
+        // nested child gesture (LongPress, Pan, etc.) inside
+        // `staticPinIcon` before it had a chance to activate. Activation
+        // happens later, only on the unambiguous pinch case (2nd finger).
         stateManager.begin();
         firstTouch.value = { x: e.allTouches[0].x, y: e.allTouches[0].y };
         _handlePanResponderGrant(e);
@@ -1578,10 +1576,11 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
       // reviewers kept finding gaps.
       if (e.numberOfTouches >= 2) {
         // Pinch is unambiguous from the moment the 2nd finger lands. Claim
-        // the touch now so the parent owns the pinch even if a child gesture
-        // earlier started competing for the 1st finger — child gestures
-        // inside `staticPinIcon` are expected to be single-touch (tap, long
-        // press, drag); a 2-finger session is the parent's domain.
+        // the touch now so the ZoomableView owns the pinch even if a
+        // nested gesture was competing for the 1st finger — nested
+        // gestures inside `staticPinIcon` are expected to be single-touch
+        // (tap, long press, drag); a 2-finger session is the ZoomableView's
+        // domain.
         stateManager.activate();
         // Long-press is a single-finger gesture — disarm any armed timer.
         // Safe no-op if the simultaneous-case long-press gate in
@@ -1620,7 +1619,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
       const dx = e.allTouches[0].x - (firstTouch.value?.x || 0);
       const dy = e.allTouches[0].y - (firstTouch.value?.y || 0);
       // 1-finger moves stay BEGAN. Multi-finger is unambiguous pinch and
-      // the parent must own it.
+      // the ZoomableView must own it.
       if (e.numberOfTouches >= 2) {
         stateManager.activate();
       }

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -197,6 +197,26 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
   // callbacks): 2nd finger touches down, 1-finger movement crosses
   // `ACTIVATION_PX`, or the long-press timer fires. Reset in `onFinalize`.
   const parentActivated = useSharedValue(false);
+  // UI-thread synchronous "pause canvas" flag. Consumers nesting their own
+  // gesture inside `staticPinIcon` can set this `true` from the very first
+  // touch worklet (`onTouchesDown` / `onBegin`) so the parent skips canvas
+  // offset writes from frame 1. Both worklets run on the UI thread in the
+  // same JS context, so the parent reads the latest value with zero
+  // dispatch latency — closing the leak window where RNGH's cross-detector
+  // cancel via `.blocksExternalGesture(parentGestureRef)` had not yet
+  // arrived but the child gesture was still in BEGAN (so its `onUpdate`
+  // hadn't fired and the parent was the only handler writing state).
+  // Exposed via `useZoomableViewPauseCanvas()`. Consumers reset it on
+  // their gesture's `onEnd` / `onFinalize`.
+  const pauseCanvas = useSharedValue(false);
+  // Debug counters: `parentShiftAttemptCount` increments on every
+  // `_handleShifting` call past its panEnabled / shift-validity checks
+  // (i.e. every frame the parent would have written if not suppressed);
+  // `parentShiftCount` increments only on actual offset writes (after the
+  // `pauseCanvas` gate). The two together let the example distinguish
+  // "child suppressed the parent" from "parent never had touches".
+  const parentShiftAttemptCount = useSharedValue(0);
+  const parentShiftCount = useSharedValue(0);
   // JS-thread mirror of `gestureStarted` exposed via the imperative handle.
   // The UI-thread `gestureStarted` SharedValue must reset synchronously at
   // the end of `_handlePanResponderEnd` so subsequent `onTouchesMove`
@@ -1016,16 +1036,26 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     });
     if (!shift) return;
 
-    // Until the parent gesture has earned the touch (movement past the
-    // activation threshold, 2nd finger, or long-press), suppress the
-    // offset write. `_calcOffsetShiftSinceLastGestureState` above has
-    // already advanced `lastGestureCenterPosition` to the current point,
-    // so the first shift after activation produces a single-frame delta
-    // — no visual jump from the touch-down point to where the finger is
-    // when parent activates. This is what stops the canvas from "creeping"
-    // during the first ~10 pixels of a knob/pin pan that a child gesture
-    // is about to claim.
-    if (!parentActivated.value) return;
+    // Debug: count attempts (every _handleShifting call past the panEnabled
+    // / shift-validity checks) regardless of whether the pause/gate skips
+    // the write. Lets the example surface "parent tried to write but was
+    // suppressed" vs "parent actually wrote".
+    parentShiftAttemptCount.value = parentShiftAttemptCount.value + 1;
+
+    // Synchronous UI-thread pause flag. A consumer's nested gesture sets
+    // this `true` from its `onTouchesDown` / `onBegin` worklet — that
+    // worklet runs on the UI thread before the parent's next
+    // `_handleShifting` worklet, so the parent reads the latest value with
+    // zero dispatch latency and skips its offset write. RNGH's cross-detector
+    // cancel via `.blocksExternalGesture(parentGestureRef)` is what
+    // ultimately ends the parent gesture, but it arrives 1-N frames after
+    // the child finally activates; this flag closes the window where the
+    // child is still in BEGAN and the parent is still the sole handler
+    // writing to the canvas.
+    if (pauseCanvas.value) return;
+
+    // Debug: count parent shifts that actually wrote offsets.
+    parentShiftCount.value = parentShiftCount.value + 1;
 
     const newOffsetX = offsetX.value + shift.x;
     const newOffsetY = offsetY.value + shift.y;
@@ -1637,23 +1667,29 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     .onTouchesMove((e, stateManager) => {
       const dx = e.allTouches[0].x - (firstTouch.value?.x || 0);
       const dy = e.allTouches[0].y - (firstTouch.value?.y || 0);
-      // Earn the gesture: once the user crosses ~10px of movement (or has
-      // 2 fingers down), this is unambiguously a pan/pinch and the parent
-      // claims the touch. Below threshold the parent stays BEGAN so any
-      // nested child gesture (LongPress, Tap, Pan with default minDistance,
-      // etc.) has a wide enough window to activate first. The threshold is
-      // intentionally larger than the 2px shift-detection threshold used by
-      // `_handlePanResponderMove` for `gestureType='shift'` classification:
-      // shift classification gates internal panning math, while activation
-      // gates RNGH ownership of the touch — the latter needs slack so brief
-      // jitter at the start of a child Pan does not wrest the touch from
-      // the child before its own minDistance fires.
-      const ACTIVATION_PX = 10;
-      if (
-        e.numberOfTouches >= 2 ||
-        Math.abs(dx) > ACTIVATION_PX ||
-        Math.abs(dy) > ACTIVATION_PX
-      ) {
+      // Earn the gesture: once the user crosses the activation threshold
+      // (or has 2 fingers down), this is unambiguously a pan/pinch and the
+      // parent claims the touch. Below threshold the parent stays BEGAN so
+      // any nested child gesture (LongPress, Tap, Pan, Rotation, etc.) has
+      // a wide enough window to activate first.
+      //
+      // The threshold has to be large enough that a child Pan (which uses
+      // `.blocksExternalGesture(parentGestureRef)` to FAIL the parent on
+      // child activation) gets there first — otherwise the parent activates
+      // first and writes one or more frames of canvas pan before being
+      // blocked. Empirically with the default RN Pan minDistance of 0 plus
+      // iOS native slop, child Pan reliably activates well under 30 px;
+      // anything below ~25 px lets the parent slip in a frame of writes.
+      // 30 px is conservative — `_handleShifting` is also gated by
+      // `parentActivated`, so off-pin canvas pan kicks in cleanly the
+      // moment the threshold is crossed (no creep, no jump).
+      // Activate ONLY for multi-finger (pinch is unambiguous and the parent
+      // must own it). 1-finger moves stay BEGAN — `blocksExternalGesture`
+      // from any nested child gesture is what cancels the parent at the
+      // RNGH tree level. Canvas-pan suppression while a child is in BEGAN
+      // (before its native activation) is handled by the synchronous
+      // `pauseCanvas` SharedValue — see `_handleShifting`.
+      if (e.numberOfTouches >= 2) {
         activateIfNeeded(stateManager);
       }
       _handlePanResponderMove(e, { dx, dy });
@@ -1703,6 +1739,9 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
         offsetX,
         offsetY,
         parentGestureRef,
+        parentShiftCount,
+        parentShiftAttemptCount,
+        pauseCanvas,
       }}
     >
       <GestureDetector gesture={gesture}>

--- a/src/ReactNativeZoomableViewContext.tsx
+++ b/src/ReactNativeZoomableViewContext.tsx
@@ -1,5 +1,4 @@
-import React, { createContext, ReactNode, RefObject, useContext } from 'react';
-import type { GestureType } from 'react-native-gesture-handler';
+import React, { createContext, ReactNode, useContext } from 'react';
 import { DerivedValue, SharedValue } from 'react-native-reanimated';
 
 type ZoomableViewContextValue = {
@@ -13,34 +12,15 @@ type ZoomableViewContextValue = {
   inverseZoomStyle: { transform: { scale: SharedValue<number> }[] };
   offsetX: SharedValue<number>;
   offsetY: SharedValue<number>;
-  // Stable RNGH ref for the parent's pan/pinch `Gesture.Manual()`, attached
-  // via `.withRef(parentGestureRef)`. Consumers nesting their own
-  // `GestureDetector` inside `staticPinIcon` (or anywhere inside the zoom
-  // subject) can compose against it — typically with
-  // `myGesture.blocksExternalGesture(parentGestureRef)` so the parent FAILs
-  // when the child activates, preventing the canvas from panning while a
-  // child Pan / Rotation / etc. is running. RNGH does NOT auto-coordinate
-  // across `GestureDetector` boundaries, so without this composition the
-  // parent and child both run concurrently and both write their state.
-  parentGestureRef: RefObject<GestureType | undefined>;
-  // Debug counter — increments every time the parent's `_handleShifting`
-  // writes a new offset. Used by the example to verify whether nested child
-  // gestures composed via `.blocksExternalGesture(parentGestureRef)` are
-  // actually preventing the parent from panning the canvas concurrently.
-  parentShiftCount: SharedValue<number>;
-  // Debug counter — increments on every `_handleShifting` call past
-  // panEnabled/shift-validity, regardless of whether the pause flag
-  // suppresses the actual offset write. Difference vs `parentShiftCount`
-  // shows how many frames the pause flag intercepted.
-  parentShiftAttemptCount: SharedValue<number>;
-  // Synchronous UI-thread "pause canvas pan" flag. Consumers nesting their
-  // own gesture inside `staticPinIcon` set this `true` from their first
-  // touch worklet (`onTouchesDown` / `onBegin`) and `false` on `onEnd` /
-  // `onFinalize`. The parent's `_handleShifting` reads this on every frame
-  // and skips its offset write when set — closing the leak window where a
-  // child gesture is still in BEGAN (before its native activation) and the
-  // parent is the only handler writing canvas state. Use the
-  // `useZoomableViewPauseCanvas()` hook to access from a consumer.
+  // Synchronous UI-thread "pause parent gesture" flag. A consumer nesting
+  // their own gesture inside `staticPinIcon` (or anywhere in the zoom
+  // subject) sets this `true` from their gesture's first-touch worklet
+  // (`onTouchesDown` / `onBegin`) and `false` on `onFinalize`. While set,
+  // the parent ZoomableView skips its canvas-pan offset writes, its
+  // long-press timer, and its tap classification — leaving the touch
+  // entirely to the consumer's gesture. Both worklets run on the same UI
+  // thread JS context, so the parent reads the latest value with zero
+  // dispatch latency (no native gesture-recognizer round-trip).
   pauseCanvas: SharedValue<boolean>;
 };
 
@@ -69,52 +49,3 @@ export const useZoomableViewContext = () => {
   }
   return context;
 };
-
-/**
- * Hook returning a `SharedValue<boolean>` that pauses the parent's
- * canvas pan in real time. Set `true` from the consumer's gesture
- * `onTouchesDown` / `onBegin` worklet and `false` from `onEnd` /
- * `onFinalize` so the parent stops writing canvas offsets the moment the
- * consumer's gesture starts receiving touches:
- *
- * ```tsx
- * const pauseCanvas = useZoomableViewPauseCanvas();
- * const myPan = useMemo(
- *   () =>
- *     Gesture.Pan()
- *       .onTouchesDown(() => { 'worklet'; pauseCanvas.value = true; })
- *       .onUpdate(...)
- *       .onFinalize(() => { 'worklet'; pauseCanvas.value = false; }),
- *   [pauseCanvas]
- * );
- * ```
- *
- * Both worklets run on the UI thread in the same JS context, so the parent
- * reads the latest value with zero dispatch latency. Pair with
- * `useZoomableViewParentGestureRef()` + `.blocksExternalGesture(parentRef)`:
- * `pauseCanvas` closes the leak window before native activation, and
- * `blocksExternalGesture` cancels the parent gesture once the consumer's
- * gesture activates natively.
- */
-export const useZoomableViewPauseCanvas = () =>
-  useZoomableViewContext().pauseCanvas;
-
-/**
- * Hook returning the parent `ReactNativeZoomableView`'s pan/pinch gesture
- * ref. Use it to give a nested gesture priority on the regions it covers:
- *
- * ```tsx
- * const parentRef = useZoomableViewParentGestureRef();
- * const myPan = useMemo(
- *   () => Gesture.Pan().onUpdate(...).blocksExternalGesture(parentRef),
- *   [parentRef]
- * );
- * ```
- *
- * `blocksExternalGesture` makes the parent FAIL when this gesture activates,
- * so the canvas does not pan while the nested gesture is running. Areas of
- * the pin not wrapped in a child `GestureDetector` continue to forward
- * touches to the parent — canvas pan still works there.
- */
-export const useZoomableViewParentGestureRef = () =>
-  useZoomableViewContext().parentGestureRef;

--- a/src/ReactNativeZoomableViewContext.tsx
+++ b/src/ReactNativeZoomableViewContext.tsx
@@ -12,15 +12,16 @@ type ZoomableViewContextValue = {
   inverseZoomStyle: { transform: { scale: SharedValue<number> }[] };
   offsetX: SharedValue<number>;
   offsetY: SharedValue<number>;
-  // Synchronous UI-thread "pause parent gesture" flag. A consumer nesting
-  // their own gesture inside `staticPinIcon` (or anywhere in the zoom
-  // subject) sets this `true` from their gesture's first-touch worklet
+  // Synchronous UI-thread flag that pauses the ZoomableView's own
+  // pan/pinch/tap/long-press handling. A consumer nesting their own
+  // gesture inside `staticPinIcon` (or anywhere in the zoom subject) sets
+  // this `true` from their gesture's first-touch worklet
   // (`onTouchesDown` / `onBegin`) and `false` on `onFinalize`. While set,
-  // the parent ZoomableView skips its canvas-pan offset writes, its
-  // long-press timer, and its tap classification — leaving the touch
-  // entirely to the consumer's gesture. Both worklets run on the same UI
-  // thread JS context, so the parent reads the latest value with zero
-  // dispatch latency (no native gesture-recognizer round-trip).
+  // the ZoomableView skips canvas pan offset writes, its long-press
+  // timer, and its tap classification — leaving the touch entirely to
+  // the consumer's gesture. Both worklets run on the same UI thread JS
+  // context, so the read here is synchronous (no native
+  // gesture-recognizer round-trip).
   pauseCanvas: SharedValue<boolean>;
 };
 

--- a/src/ReactNativeZoomableViewContext.tsx
+++ b/src/ReactNativeZoomableViewContext.tsx
@@ -23,6 +23,25 @@ type ZoomableViewContextValue = {
   // across `GestureDetector` boundaries, so without this composition the
   // parent and child both run concurrently and both write their state.
   parentGestureRef: RefObject<GestureType | undefined>;
+  // Debug counter — increments every time the parent's `_handleShifting`
+  // writes a new offset. Used by the example to verify whether nested child
+  // gestures composed via `.blocksExternalGesture(parentGestureRef)` are
+  // actually preventing the parent from panning the canvas concurrently.
+  parentShiftCount: SharedValue<number>;
+  // Debug counter — increments on every `_handleShifting` call past
+  // panEnabled/shift-validity, regardless of whether the pause flag
+  // suppresses the actual offset write. Difference vs `parentShiftCount`
+  // shows how many frames the pause flag intercepted.
+  parentShiftAttemptCount: SharedValue<number>;
+  // Synchronous UI-thread "pause canvas pan" flag. Consumers nesting their
+  // own gesture inside `staticPinIcon` set this `true` from their first
+  // touch worklet (`onTouchesDown` / `onBegin`) and `false` on `onEnd` /
+  // `onFinalize`. The parent's `_handleShifting` reads this on every frame
+  // and skips its offset write when set — closing the leak window where a
+  // child gesture is still in BEGAN (before its native activation) and the
+  // parent is the only handler writing canvas state. Use the
+  // `useZoomableViewPauseCanvas()` hook to access from a consumer.
+  pauseCanvas: SharedValue<boolean>;
 };
 
 const ReactNativeZoomableViewContext =
@@ -50,6 +69,35 @@ export const useZoomableViewContext = () => {
   }
   return context;
 };
+
+/**
+ * Hook returning a `SharedValue<boolean>` that pauses the parent's
+ * canvas pan in real time. Set `true` from the consumer's gesture
+ * `onTouchesDown` / `onBegin` worklet and `false` from `onEnd` /
+ * `onFinalize` so the parent stops writing canvas offsets the moment the
+ * consumer's gesture starts receiving touches:
+ *
+ * ```tsx
+ * const pauseCanvas = useZoomableViewPauseCanvas();
+ * const myPan = useMemo(
+ *   () =>
+ *     Gesture.Pan()
+ *       .onTouchesDown(() => { 'worklet'; pauseCanvas.value = true; })
+ *       .onUpdate(...)
+ *       .onFinalize(() => { 'worklet'; pauseCanvas.value = false; }),
+ *   [pauseCanvas]
+ * );
+ * ```
+ *
+ * Both worklets run on the UI thread in the same JS context, so the parent
+ * reads the latest value with zero dispatch latency. Pair with
+ * `useZoomableViewParentGestureRef()` + `.blocksExternalGesture(parentRef)`:
+ * `pauseCanvas` closes the leak window before native activation, and
+ * `blocksExternalGesture` cancels the parent gesture once the consumer's
+ * gesture activates natively.
+ */
+export const useZoomableViewPauseCanvas = () =>
+  useZoomableViewContext().pauseCanvas;
 
 /**
  * Hook returning the parent `ReactNativeZoomableView`'s pan/pinch gesture

--- a/src/ReactNativeZoomableViewContext.tsx
+++ b/src/ReactNativeZoomableViewContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, ReactNode, useContext } from 'react';
+import React, { createContext, ReactNode, RefObject, useContext } from 'react';
+import type { GestureType } from 'react-native-gesture-handler';
 import { DerivedValue, SharedValue } from 'react-native-reanimated';
 
 type ZoomableViewContextValue = {
@@ -12,6 +13,16 @@ type ZoomableViewContextValue = {
   inverseZoomStyle: { transform: { scale: SharedValue<number> }[] };
   offsetX: SharedValue<number>;
   offsetY: SharedValue<number>;
+  // Stable RNGH ref for the parent's pan/pinch `Gesture.Manual()`, attached
+  // via `.withRef(parentGestureRef)`. Consumers nesting their own
+  // `GestureDetector` inside `staticPinIcon` (or anywhere inside the zoom
+  // subject) can compose against it — typically with
+  // `myGesture.blocksExternalGesture(parentGestureRef)` so the parent FAILs
+  // when the child activates, preventing the canvas from panning while a
+  // child Pan / Rotation / etc. is running. RNGH does NOT auto-coordinate
+  // across `GestureDetector` boundaries, so without this composition the
+  // parent and child both run concurrently and both write their state.
+  parentGestureRef: RefObject<GestureType | undefined>;
 };
 
 const ReactNativeZoomableViewContext =
@@ -39,3 +50,23 @@ export const useZoomableViewContext = () => {
   }
   return context;
 };
+
+/**
+ * Hook returning the parent `ReactNativeZoomableView`'s pan/pinch gesture
+ * ref. Use it to give a nested gesture priority on the regions it covers:
+ *
+ * ```tsx
+ * const parentRef = useZoomableViewParentGestureRef();
+ * const myPan = useMemo(
+ *   () => Gesture.Pan().onUpdate(...).blocksExternalGesture(parentRef),
+ *   [parentRef]
+ * );
+ * ```
+ *
+ * `blocksExternalGesture` makes the parent FAIL when this gesture activates,
+ * so the canvas does not pan while the nested gesture is running. Areas of
+ * the pin not wrapped in a child `GestureDetector` continue to forward
+ * touches to the parent — canvas pan still works there.
+ */
+export const useZoomableViewParentGestureRef = () =>
+  useZoomableViewContext().parentGestureRef;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,11 +5,7 @@ import {
   viewportPositionToImagePosition,
 } from './helper/coordinateConversion';
 import { ReactNativeZoomableView } from './ReactNativeZoomableView';
-import {
-  useZoomableViewContext,
-  useZoomableViewParentGestureRef,
-  useZoomableViewPauseCanvas,
-} from './ReactNativeZoomableViewContext';
+import { useZoomableViewContext } from './ReactNativeZoomableViewContext';
 import type {
   ReactNativeZoomableViewProps,
   ReactNativeZoomableViewRef,
@@ -28,8 +24,6 @@ export {
   ReactNativeZoomableViewRef,
   Size2D,
   useZoomableViewContext,
-  useZoomableViewParentGestureRef,
-  useZoomableViewPauseCanvas,
   Vec2D,
   viewportPositionToImagePosition,
   ZoomableViewEvent,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import { ReactNativeZoomableView } from './ReactNativeZoomableView';
 import {
   useZoomableViewContext,
   useZoomableViewParentGestureRef,
+  useZoomableViewPauseCanvas,
 } from './ReactNativeZoomableViewContext';
 import type {
   ReactNativeZoomableViewProps,
@@ -28,6 +29,7 @@ export {
   Size2D,
   useZoomableViewContext,
   useZoomableViewParentGestureRef,
+  useZoomableViewPauseCanvas,
   Vec2D,
   viewportPositionToImagePosition,
   ZoomableViewEvent,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,10 @@ import {
   viewportPositionToImagePosition,
 } from './helper/coordinateConversion';
 import { ReactNativeZoomableView } from './ReactNativeZoomableView';
-import { useZoomableViewContext } from './ReactNativeZoomableViewContext';
+import {
+  useZoomableViewContext,
+  useZoomableViewParentGestureRef,
+} from './ReactNativeZoomableViewContext';
 import type {
   ReactNativeZoomableViewProps,
   ReactNativeZoomableViewRef,
@@ -24,6 +27,7 @@ export {
   ReactNativeZoomableViewRef,
   Size2D,
   useZoomableViewContext,
+  useZoomableViewParentGestureRef,
   Vec2D,
   viewportPositionToImagePosition,
   ZoomableViewEvent,


### PR DESCRIPTION
## Summary

`ReactNativeZoomableView` wraps the zoom subject and the `StaticPin` in a single `GestureDetector` running a `Gesture.Manual()`. On every first touch the manual gesture called `stateManager.activate()` — claiming exclusive RNGH ownership before any nested `GestureDetector` placed inside `staticPinIcon` could even begin its own state machine. A consumer who passed in a pin with its own `LongPress`, `Pan`, `Rotation` etc. found those gestures swallowed.

This PR layers three changes that together let nested client gestures take priority on the regions they cover, with zero canvas drift, while non-claimed regions of the pin still forward to the canvas pan/pinch:

1. **Defer parent activation.** Parent stays BEGAN on touch-down. `Gesture.Manual().withRef(parentGestureRef)` is exposed via `useZoomableViewParentGestureRef()` so consumers can compose against it. (commit 1)
2. **Cross-detector composition via `blocksExternalGesture(parentGestureRef)`.** Consumer's nested gesture cancels the parent at the RNGH tree level once it activates. (commit 2)
3. **`useZoomableViewPauseCanvas()`** — a `SharedValue<boolean>` the consumer toggles in their gesture's `onTouchesDown`/`onFinalize` worklets. Closes the latency window where the child gesture is still in BEGAN (waiting to cross its native activation threshold) and the parent is the only handler writing canvas state. RNGH's cross-detector cancel arrives 1-N frames after native activation; this flag eliminates that leak by communicating intent on the UI thread synchronously. (commit 3)

Based on https://github.com/openspacelabs/react-native-zoomable-view/pull/151.

## Test Plan

- Run the example on a physical device. The pin renders as a red main button + a blue 100×100 knob hanging off a horizontal rail.
- Long-press the red button → "Pin long-press fired" alert (the consumer's nested `Gesture.LongPress` won — previously the parent's prop `onLongPress` fired instead).
- Pan the blue knob → knob translates, canvas does NOT drift. Released, knob snaps back. The example surfaces `parent attempts:N writes:0` as proof — `_handleShifting` was called N times during the knob pan and the `pauseCanvas` flag suppressed every write.
- Pan from empty space inside the pin's bounding box → canvas pans normally (those regions don't toggle the pause flag).
- Pan from off-pin → canvas pans normally. Counter shows `attempts:N writes:N`.
- Pinch starting anywhere → canvas zooms.
- Tap empty canvas → `onSingleTap` still fires. Long-press empty canvas → parent's prop `onLongPress` fires.

Verified on iPhone 12 Pro running PR #151's branch:
- Knob pan: `knob touchDown:1 begin:1 start:1`, `parent attempts:14 writes:0`. Pin stayed at its anchor (245, 245).
- Off-pin pan: `parent attempts:94 writes:94`. Canvas panned 100 px (matched input).

## Risk

- The new `pauseCanvas` flag is opt-in. Consumers that don't toggle it will still see the 1-N frame leak that `blocksExternalGesture` alone leaves. The example demonstrates the canonical wiring.
- Parent activation timing is now data-dependent (multi-finger only on 1-finger paths). Anything that previously assumed the parent was ACTIVE on every touch-down — a consumer reading `gestureStarted` synchronously inside `onPanResponderGrant`, for instance — could observe a different state for taps that release before pinch / long-press. Behavioral callbacks (`onPanResponderGrant`, single/double-tap detection, long-press timer) still fire from touch events; only the RNGH ownership transition shifts.
- Public API additions: `useZoomableViewParentGestureRef()`, `useZoomableViewPauseCanvas()`. Type signatures use `RefObject<GestureType | undefined>` and `SharedValue<boolean>` from `react-native-gesture-handler` and `react-native-reanimated` respectively.

## Change details

- `src/ReactNativeZoomableView.tsx`: `parentGestureRef` (`useRef<GestureType>`), `parentActivated` SharedValue, `parentShouldWrite`/`pauseCanvas` flags, `activateIfNeeded` worklet helper. Removed eager `stateManager.activate()` from `onTouchesDown`. Pinch (2nd finger) still activates immediately. Reset in `onFinalize`. `_handleShifting` early-returns when `pauseCanvas.value === true`. Debug counters (`parentShiftCount`, `parentShiftAttemptCount`) exposed via context for the example to surface attempt-vs-write metrics.
- `src/ReactNativeZoomableViewContext.tsx`: extends `ZoomableViewContextValue` with `parentGestureRef`, `parentShiftCount`, `parentShiftAttemptCount`, `pauseCanvas`. New hooks `useZoomableViewParentGestureRef()` and `useZoomableViewPauseCanvas()`.
- `src/index.tsx`: re-exports the two new hooks.
- `example/App.tsx`: extracts the demo pin into `<DemoPin>` (rendered inside `ReactNativeZoomableView` so it sees the context). Layout: 280×100 box, blue 100×100 knob on the left, red 48×48 main button on the right, joined by a rail. Both nested gestures use `.blocksExternalGesture(parentGestureRef)`. Knob's `Pan` toggles `pauseCanvas` from `onTouchesDown` and `onFinalize`. UI surfaces the diagnostic counters.
