### PR TITLE
Add contentX/contentY to ZoomableViewEvent

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -37,7 +37,7 @@ Exported from `src/index.tsx`:
 - `ReactNativeZoomableView` — main component
 - `ReactNativeZoomableViewProps` — prop type
 - `ReactNativeZoomableViewRef` — imperative handle
-- `ZoomableViewEvent` — `{ zoomLevel, offsetX, offsetY, originalWidth, originalHeight }`
+- `ZoomableViewEvent` — `{ zoomLevel, offsetX, offsetY, originalWidth, originalHeight, contentX?, contentY? }`
 - `useZoomableViewContext()` — hook returning `{ zoom, inverseZoom, inverseZoomStyle, offsetX, offsetY }` for descendants
 - `FixedSize` — wrapper that keeps absolutely-positioned children at constant visual size regardless of zoom
 - `applyContainResizeMode`, `getImageOriginOnTransformSubject`, `viewportPositionToImagePosition` — coordinate helpers
@@ -95,6 +95,8 @@ Exported from `src/index.tsx`:
 ### Callbacks
 
 All event-receiving callbacks accept `(event: GestureTouchEvent, zoomableViewEventObject: ZoomableViewEvent)`. `onZoomEnd`'s `event` is `GestureTouchEvent | undefined` (it's `undefined` on natural completion of a programmatic `zoomTo()`).
+
+The `contentX` / `contentY` fields on `ZoomableViewEvent` carry the first touch's position in content (bitmap) coordinates — populated when the callback has an associated gesture event AND both `contentWidth` and `contentHeight` props are set. Undefined for `onTransformWorklet` (no gesture event) and for `onZoomEnd` after a programmatic `zoomTo()` completes naturally (its `event` is `undefined`). Computed under the same `contain` resize-mode assumption as `viewportPositionToImagePosition` — see [Coordinate system](#coordinate-system).
 
 | Callback | Thread | When |
 |----------|--------|------|

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -344,21 +344,17 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
    * @private
    */
   const _getZoomableViewEventObject = (
-    overwriteObj: Partial<ZoomableViewEvent> = {},
     gestureEvent?: GestureTouchEvent
   ): ZoomableViewEvent => {
     'worklet';
 
-    const event: ZoomableViewEvent = Object.assign(
-      {
-        zoomLevel: zoom.value,
-        offsetX: offsetX.value,
-        offsetY: offsetY.value,
-        originalHeight: originalHeight.value,
-        originalWidth: originalWidth.value,
-      },
-      overwriteObj
-    );
+    const event: ZoomableViewEvent = {
+      zoomLevel: zoom.value,
+      offsetX: offsetX.value,
+      offsetY: offsetY.value,
+      originalHeight: originalHeight.value,
+      originalWidth: originalWidth.value,
+    };
 
     // Populate content (bitmap) coordinates of the first touch when caller
     // supplied a gesture event AND content dimensions are known.
@@ -406,11 +402,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
         height: contentHeight.value,
         width: contentWidth.value,
       },
-      zoomableEvent: _getZoomableViewEventObject({
-        offsetX: offsetX.value,
-        offsetY: offsetY.value,
-        zoomLevel: zoom.value,
-      }),
+      zoomableEvent: _getZoomableViewEventObject(),
     });
   };
 
@@ -793,7 +785,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
         // `props.onLongPress` — the closure was captured at schedule time
         // and would fire a stale callback if the parent re-rendered during
         // the timer window.
-        onLongPress(e, _getZoomableViewEventObject({}, e));
+        onLongPress(e, _getZoomableViewEventObject(e));
       }, props.longPressDuration);
     }
   });
@@ -853,7 +845,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     // the resumed gesture.
     runOnJS(setGestureStartedJS)(true);
     if (!isRecovery) {
-      runOnJS(_safeOnPanResponderGrant)(e, _getZoomableViewEventObject({}, e));
+      runOnJS(_safeOnPanResponderGrant)(e, _getZoomableViewEventObject(e));
     }
 
     cancelAnimation(zoom);
@@ -1102,7 +1094,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     const { onDoubleTapBefore, onDoubleTapAfter, doubleTapZoomToCenter } =
       props;
 
-    onDoubleTapBefore?.(e, _getZoomableViewEventObject({}, e));
+    onDoubleTapBefore?.(e, _getZoomableViewEventObject(e));
 
     const nextZoomStep = getNextZoomStep({
       zoomLevel: zoom.value,
@@ -1129,10 +1121,10 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
 
     publicZoomTo(nextZoomStep, zoomPositionCoordinates);
 
-    onDoubleTapAfter?.(
-      e,
-      _getZoomableViewEventObject({ zoomLevel: nextZoomStep }, e)
-    );
+    onDoubleTapAfter?.(e, {
+      ..._getZoomableViewEventObject(e),
+      zoomLevel: nextZoomStep,
+    });
   });
 
   /**
@@ -1212,7 +1204,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
 
         // Invoke the stable `onSingleTap` wrapper rather than the captured
         // `props.onSingleTap` — same staleness reasoning as `onLongPress`.
-        onSingleTap(e, _getZoomableViewEventObject({}, e));
+        onSingleTap(e, _getZoomableViewEventObject(e));
       }, props.doubleTapDelay);
     }
   };
@@ -1383,12 +1375,12 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
 
     runOnJS(clearLongPressTimeout)();
 
-    runOnJS(_safeOnPanResponderEnd)(e, _getZoomableViewEventObject({}, e));
+    runOnJS(_safeOnPanResponderEnd)(e, _getZoomableViewEventObject(e));
 
     if (gestureType.value === 'pinch') {
-      runOnJS(_safeOnZoomEnd)(e, _getZoomableViewEventObject({}, e));
+      runOnJS(_safeOnZoomEnd)(e, _getZoomableViewEventObject(e));
     } else if (gestureType.value === 'shift') {
-      runOnJS(_safeOnShiftingEnd)(e, _getZoomableViewEventObject({}, e));
+      runOnJS(_safeOnShiftingEnd)(e, _getZoomableViewEventObject(e));
     }
 
     // RNGH cancellation: queue `onPanResponderTerminate` HERE — inside the
@@ -1397,10 +1389,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     // `ref.current.gestureStarted` from inside `onPanResponderTerminate`
     // observes `true`, matching SPECS L157 for the other end-callbacks.
     if (isCancellation) {
-      runOnJS(_safeOnPanResponderTerminate)(
-        e,
-        _getZoomableViewEventObject({}, e)
-      );
+      runOnJS(_safeOnPanResponderTerminate)(e, _getZoomableViewEventObject(e));
       // wasReleased=false skips the suppression branch above; clear here.
       doubleTapFirstTapReleaseTimestamp.value = undefined;
       doubleTapFirstTap.value = undefined;
@@ -1444,7 +1433,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     if (
       onPanResponderMoveWorkletShared.value.fn(
         e,
-        _getZoomableViewEventObject({}, e)
+        _getZoomableViewEventObject(e)
       )
     ) {
       // Consumer intercepted this move. The early-return below skips the

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -344,11 +344,12 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
    * @private
    */
   const _getZoomableViewEventObject = (
-    overwriteObj: Partial<ZoomableViewEvent> = {}
+    overwriteObj: Partial<ZoomableViewEvent> = {},
+    gestureEvent?: GestureTouchEvent
   ): ZoomableViewEvent => {
     'worklet';
 
-    return Object.assign(
+    const event: ZoomableViewEvent = Object.assign(
       {
         zoomLevel: zoom.value,
         offsetX: offsetX.value,
@@ -358,6 +359,30 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
       },
       overwriteObj
     );
+
+    // Populate content (bitmap) coordinates of the first touch when caller
+    // supplied a gesture event AND content dimensions are known.
+    // `viewportPositionToImagePosition` divides by container size and image
+    // size, so it returns null pre-measurement or with no content size set —
+    // leave `contentX`/`contentY` undefined in that case rather than emit
+    // NaN/Infinity to consumers.
+    const touch = gestureEvent?.allTouches[0];
+    if (touch && contentWidth.value && contentHeight.value) {
+      const contentPos = viewportPositionToImagePosition({
+        viewportPosition: { x: touch.x, y: touch.y },
+        imageSize: {
+          width: contentWidth.value,
+          height: contentHeight.value,
+        },
+        zoomableEvent: event,
+      });
+      if (contentPos) {
+        event.contentX = contentPos.x;
+        event.contentY = contentPos.y;
+      }
+    }
+
+    return event;
   };
 
   const _staticPinPosition = () => {
@@ -768,7 +793,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
         // `props.onLongPress` — the closure was captured at schedule time
         // and would fire a stale callback if the parent re-rendered during
         // the timer window.
-        onLongPress(e, _getZoomableViewEventObject());
+        onLongPress(e, _getZoomableViewEventObject({}, e));
       }, props.longPressDuration);
     }
   });
@@ -828,7 +853,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     // the resumed gesture.
     runOnJS(setGestureStartedJS)(true);
     if (!isRecovery) {
-      runOnJS(_safeOnPanResponderGrant)(e, _getZoomableViewEventObject());
+      runOnJS(_safeOnPanResponderGrant)(e, _getZoomableViewEventObject({}, e));
     }
 
     cancelAnimation(zoom);
@@ -1077,7 +1102,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     const { onDoubleTapBefore, onDoubleTapAfter, doubleTapZoomToCenter } =
       props;
 
-    onDoubleTapBefore?.(e, _getZoomableViewEventObject());
+    onDoubleTapBefore?.(e, _getZoomableViewEventObject({}, e));
 
     const nextZoomStep = getNextZoomStep({
       zoomLevel: zoom.value,
@@ -1106,7 +1131,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
 
     onDoubleTapAfter?.(
       e,
-      _getZoomableViewEventObject({ zoomLevel: nextZoomStep })
+      _getZoomableViewEventObject({ zoomLevel: nextZoomStep }, e)
     );
   });
 
@@ -1187,7 +1212,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
 
         // Invoke the stable `onSingleTap` wrapper rather than the captured
         // `props.onSingleTap` — same staleness reasoning as `onLongPress`.
-        onSingleTap(e, _getZoomableViewEventObject());
+        onSingleTap(e, _getZoomableViewEventObject({}, e));
       }, props.doubleTapDelay);
     }
   };
@@ -1358,12 +1383,12 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
 
     runOnJS(clearLongPressTimeout)();
 
-    runOnJS(_safeOnPanResponderEnd)(e, _getZoomableViewEventObject());
+    runOnJS(_safeOnPanResponderEnd)(e, _getZoomableViewEventObject({}, e));
 
     if (gestureType.value === 'pinch') {
-      runOnJS(_safeOnZoomEnd)(e, _getZoomableViewEventObject());
+      runOnJS(_safeOnZoomEnd)(e, _getZoomableViewEventObject({}, e));
     } else if (gestureType.value === 'shift') {
-      runOnJS(_safeOnShiftingEnd)(e, _getZoomableViewEventObject());
+      runOnJS(_safeOnShiftingEnd)(e, _getZoomableViewEventObject({}, e));
     }
 
     // RNGH cancellation: queue `onPanResponderTerminate` HERE — inside the
@@ -1372,7 +1397,10 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     // `ref.current.gestureStarted` from inside `onPanResponderTerminate`
     // observes `true`, matching SPECS L157 for the other end-callbacks.
     if (isCancellation) {
-      runOnJS(_safeOnPanResponderTerminate)(e, _getZoomableViewEventObject());
+      runOnJS(_safeOnPanResponderTerminate)(
+        e,
+        _getZoomableViewEventObject({}, e)
+      );
       // wasReleased=false skips the suppression branch above; clear here.
       doubleTapFirstTapReleaseTimestamp.value = undefined;
       doubleTapFirstTap.value = undefined;
@@ -1414,7 +1442,10 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     'worklet';
 
     if (
-      onPanResponderMoveWorkletShared.value.fn(e, _getZoomableViewEventObject())
+      onPanResponderMoveWorkletShared.value.fn(
+        e,
+        _getZoomableViewEventObject({}, e)
+      )
     ) {
       // Consumer intercepted this move. The early-return below skips the
       // gesture-classification branches that would otherwise assign

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -8,6 +8,15 @@ export interface ZoomableViewEvent {
   offsetY: number;
   originalHeight: number;
   originalWidth: number;
+  /**
+   * Position of the gesture's first touch in content (bitmap) coordinates.
+   * Populated only when the callback has an associated gesture event AND
+   * both `contentWidth` and `contentHeight` props are set. Undefined for
+   * non-gesture call sites (`onTransformWorklet`, `onZoomEnd` after a
+   * programmatic `zoomTo()`) and when content dimensions are unknown.
+   */
+  contentX?: number;
+  contentY?: number;
 }
 
 export type ReactNativeZoomableViewRef = {


### PR DESCRIPTION
## Summary
- Add optional `contentX` / `contentY` to `ZoomableViewEvent` carrying the gesture's first touch in content (bitmap) coordinates — so consumers can tell where the user tapped on the contents.
- Populated when the callback has an associated `GestureTouchEvent` AND both `contentWidth` and `contentHeight` props are set. Computed via the existing `viewportPositionToImagePosition` helper (same `contain` resize-mode assumption).
- Undefined for non-gesture call sites (`onTransformWorklet`, `onZoomEnd` after a programmatic `zoomTo()` completes naturally) and when content dimensions aren't configured.
- SPECS.md updated to reflect the new event shape and document when the fields are populated.

## Test plan
- [ ] Verify a single tap fires `onSingleTap` with `contentX`/`contentY` set when `contentWidth`/`contentHeight` are configured.
- [ ] Verify `contentX`/`contentY` are undefined when `contentWidth`/`contentHeight` are not set.
- [ ] Verify `contentX`/`contentY` are undefined on `onZoomEnd` fired from programmatic `zoomTo()` completion (no gesture event).
- [ ] Verify values are reasonable across zoom levels (taps near edges and after pan/zoom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)