### PR TITLE
Fix the crash on adding a touch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspacelabs/react-native-zoomable-view",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "A view component for react-native with pinch to zoom, tap to move and double tap to zoom capability.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -413,7 +413,7 @@ const ReactNativeZoomableViewInner: ForwardRefRenderFunction<
     // `AnimatedTouchFeedback.onAnimationDone`, which never mounts when the
     // render gate fails.
     if (!visualTouchFeedbackEnabled || !doubleTapDelay) return;
-    touches.value.push(touch);
+    touches.value = [...touches.value, touch];
     setStateTouches([...touches.value]);
   });
 


### PR DESCRIPTION
Using `value.push` seems to break against the new React Native. This causes taps on the sheet to crash the app with this error:

<img width="739" height="1527" alt="image" src="https://github.com/user-attachments/assets/1cc67a28-127e-47ca-909e-dde2e528c4db" />

This is because in Hermes some objects are extensible and some aren't. This seems to have changed in the updated version of Hermes. There are [reports of the same error](https://stackoverflow.com/questions/77327220/push-function-shows-error-message-cannot-add-a-new-property) so this is not a new problem, just a new instance of it.

Replacing the line with `touches.value = [...touches.value, touch];` seems to solve it perfect.y

```
Uncaught Error

cannot add a new property

Source:
/Users/elliott/Sites/diana/node_modules/@openspacelabs/react-native-zoomable-view/src/ReactNativeZoomableView.tsx (417:4)

Call Stack:
useLatestCallback$argument_0 (/Users/elliott/Sites/diana/node_modules/@openspacelabs/react-native-zoomable-view/src/ReactNativeZoomableView.tsx:417)
<global> (/Users/elliott/Sites/diana/node_modules/@openspacelabs/react-native-zoomable-view/src/hooks/useLatestCallback.ts:14)
_resolveAndHandleTap (/Users/elliott/Sites/diana/node_modules/@openspacelabs/react-native-zoomable-view/src/ReactNativeZoomableView.tsx:1171)
```